### PR TITLE
Feat/사용자 로그인 회원가입

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/Seat.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/Seat.java
@@ -1,5 +1,6 @@
 package org.codeNbug.mainserver.domain.seat.entity;
 
+import org.codeNbug.mainserver.domain.manager.entity.Event;
 import org.codeNbug.mainserver.domain.mock.entity.Ticket;
 
 import jakarta.persistence.Entity;
@@ -26,7 +27,7 @@ public class Seat {
 	@NotNull
 	private boolean available = true;
 
-	@OneToOne
+	@ManyToOne
 	@JoinColumn(name = "grade_id", nullable = false)
 	private SeatGrade gradeId;
 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/SeatGrade.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/SeatGrade.java
@@ -1,5 +1,7 @@
 package org.codeNbug.mainserver.domain.seat.entity;
 
+import org.codeNbug.mainserver.domain.manager.entity.Event;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/controller/UserController.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/controller/UserController.java
@@ -1,7 +1,112 @@
 package org.codeNbug.mainserver.domain.user.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.codeNbug.mainserver.domain.user.dto.request.LoginRequest;
+import org.codeNbug.mainserver.domain.user.dto.response.LoginResponse;
+import org.codeNbug.mainserver.domain.user.dto.request.SignupRequest;
+import org.codeNbug.mainserver.domain.user.dto.response.SignupResponse;
+import org.codeNbug.mainserver.domain.user.service.UserService;
+import org.codeNbug.mainserver.global.dto.ApiResponse;
+import org.codeNbug.mainserver.global.exception.globalException.DuplicateEmailException;
+import org.codeNbug.mainserver.global.exception.security.AuthenticationFailedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
+    private final UserService userService;
+
+    /**
+     * 회원가입 API
+     *
+     * @param request 회원가입 요청 정보
+     * @param bindingResult 유효성 검사 결과
+     * @return API 응답
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(
+            @Valid @RequestBody SignupRequest request,
+            BindingResult bindingResult) {
+
+        // 입력값 유효성 검사
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+        }
+
+        try {
+            // 회원가입 처리
+            SignupResponse response = userService.signup(request);
+            return ResponseEntity.ok(
+                    ApiResponse.success("회원가입 성공", response));
+        } catch (DuplicateEmailException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.error(409, e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error(500, "서버 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 로그인 API
+     *
+     * @param request 로그인 요청 정보
+     * @param bindingResult 유효성 검사 결과
+     * @param response HTTP 응답 객체 (쿠키 설정용)
+     * @return API 응답
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            BindingResult bindingResult,
+            HttpServletResponse response) {
+
+        // 입력값 유효성 검사
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+        }
+
+        try {
+            // 로그인 처리
+            LoginResponse loginResponse = userService.login(request);
+            
+            // 쿠키에 토큰 설정
+            Cookie accessTokenCookie = new Cookie("accessToken", loginResponse.getAccessToken());
+            accessTokenCookie.setHttpOnly(true);
+            accessTokenCookie.setPath("/");
+            accessTokenCookie.setSecure(true); // HTTPS에서만 전송
+            accessTokenCookie.setAttribute("SameSite", "None"); // 크로스 사이트 요청 허용
+            
+            Cookie refreshTokenCookie = new Cookie("refreshToken", loginResponse.getRefreshToken());
+            refreshTokenCookie.setHttpOnly(true);
+            refreshTokenCookie.setPath("/auth/refresh");
+            refreshTokenCookie.setSecure(true);
+            refreshTokenCookie.setAttribute("SameSite", "None");
+            
+            response.addCookie(accessTokenCookie);
+            response.addCookie(refreshTokenCookie);
+            
+            return ResponseEntity.ok(
+                    ApiResponse.success("로그인 성공", loginResponse));
+            
+        } catch (AuthenticationFailedException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(401, e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError()
+                    .body(ApiResponse.error(500, "서버 오류가 발생했습니다."));
+        }
+    }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/controller/UserController.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/controller/UserController.java
@@ -9,7 +9,7 @@ import org.codeNbug.mainserver.domain.user.dto.response.LoginResponse;
 import org.codeNbug.mainserver.domain.user.dto.request.SignupRequest;
 import org.codeNbug.mainserver.domain.user.dto.response.SignupResponse;
 import org.codeNbug.mainserver.domain.user.service.UserService;
-import org.codeNbug.mainserver.global.dto.ApiResponse;
+import org.codeNbug.mainserver.global.dto.RsData;
 import org.codeNbug.mainserver.global.exception.globalException.DuplicateEmailException;
 import org.codeNbug.mainserver.global.exception.security.AuthenticationFailedException;
 import org.springframework.http.HttpStatus;
@@ -34,27 +34,27 @@ public class UserController {
      * @return API 응답
      */
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignupResponse>> signup(
+    public ResponseEntity<RsData<SignupResponse>> signup(
             @Valid @RequestBody SignupRequest request,
             BindingResult bindingResult) {
 
         // 입력값 유효성 검사
         if (bindingResult.hasErrors()) {
             return ResponseEntity.badRequest()
-                    .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+                    .body(new RsData<>("400-BAD_REQUEST", "데이터 형식이 잘못되었습니다."));
         }
 
         try {
             // 회원가입 처리
             SignupResponse response = userService.signup(request);
             return ResponseEntity.ok(
-                    ApiResponse.success("회원가입 성공", response));
+                    new RsData<>("200-SUCCESS", "회원가입 성공", response));
         } catch (DuplicateEmailException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(ApiResponse.error(409, e.getMessage()));
+                    .body(new RsData<>("409-CONFLICT", e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
-                    .body(ApiResponse.error(500, "서버 오류가 발생했습니다."));
+                    .body(new RsData<>("500-INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."));
         }
     }
 
@@ -67,7 +67,7 @@ public class UserController {
      * @return API 응답
      */
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(
+    public ResponseEntity<RsData<LoginResponse>> login(
             @Valid @RequestBody LoginRequest request,
             BindingResult bindingResult,
             HttpServletResponse response) {
@@ -75,7 +75,7 @@ public class UserController {
         // 입력값 유효성 검사
         if (bindingResult.hasErrors()) {
             return ResponseEntity.badRequest()
-                    .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+                    .body(new RsData<>("400-BAD_REQUEST", "데이터 형식이 잘못되었습니다."));
         }
 
         try {
@@ -99,14 +99,14 @@ public class UserController {
             response.addCookie(refreshTokenCookie);
             
             return ResponseEntity.ok(
-                    ApiResponse.success("로그인 성공", loginResponse));
+                    new RsData<>("200-SUCCESS", "로그인 성공", loginResponse));
             
         } catch (AuthenticationFailedException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.error(401, e.getMessage()));
+                    .body(new RsData<>("401-UNAUTHORIZED", e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
-                    .body(ApiResponse.error(500, "서버 오류가 발생했습니다."));
+                    .body(new RsData<>("500-INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."));
         }
     }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/request/LoginRequest.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,24 @@
+package org.codeNbug.mainserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/request/SignupRequest.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/request/SignupRequest.java
@@ -1,0 +1,63 @@
+package org.codeNbug.mainserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.codeNbug.mainserver.domain.user.entity.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 회원가입 요청 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 필수 입력 항목입니다.")
+    private String name;
+
+    @NotNull(message = "나이는 필수 입력 항목입니다.")
+    private Integer age;
+
+    @NotBlank(message = "성별은 필수 입력 항목입니다.")
+    private String sex;
+
+    @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
+    private String phoneNum;
+
+    @NotBlank(message = "주소는 필수 입력 항목입니다.")
+    private String location;
+
+    /**
+     * SignupRequest를 User 엔티티로 변환
+     *
+     * @param passwordEncoder 비밀번호 인코더
+     * @return User 엔티티
+     */
+    public User toEntity(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .email(this.email)
+                .password(passwordEncoder.encode(this.password))
+                .name(this.name)
+                .age(this.age)
+                .sex(this.sex)
+                .phoneNum(this.phoneNum)
+                .location(this.location)
+                .role("ROLE_USER")
+                .build();
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/response/LoginResponse.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/response/LoginResponse.java
@@ -1,0 +1,34 @@
+package org.codeNbug.mainserver.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String tokenType;
+    private String accessToken;
+    private String refreshToken;
+
+    /**
+     * 토큰 정보로 LoginResponse 생성
+     *
+     * @param accessToken  액세스 토큰
+     * @param refreshToken 리프레시 토큰
+     * @return LoginResponse 객체
+     */
+    public static LoginResponse of(String accessToken, String refreshToken) {
+        return LoginResponse.builder()
+                .tokenType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/response/SignupResponse.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/dto/response/SignupResponse.java
@@ -1,0 +1,46 @@
+package org.codeNbug.mainserver.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.codeNbug.mainserver.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원가입 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupResponse {
+    private Long id;
+    private String email;
+    private String name;
+    private Integer age;
+    private String sex;
+    private String phoneNum;
+    private String location;
+    private LocalDateTime createdAt;
+
+    /**
+     * User 엔티티를 SignupResponse DTO로 변환
+     *
+     * @param user User 엔티티
+     * @return SignupResponse DTO
+     */
+    public static SignupResponse fromEntity(User user) {
+        return SignupResponse.builder()
+                .id(user.getUserId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .age(user.getAge())
+                .sex(user.getSex())
+                .phoneNum(user.getPhoneNum())
+                .location(user.getLocation())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/service/UserService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/user/service/UserService.java
@@ -1,7 +1,71 @@
 package org.codeNbug.mainserver.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.codeNbug.mainserver.domain.user.dto.request.LoginRequest;
+import org.codeNbug.mainserver.domain.user.dto.response.LoginResponse;
+import org.codeNbug.mainserver.domain.user.dto.request.SignupRequest;
+import org.codeNbug.mainserver.domain.user.dto.response.SignupResponse;
+import org.codeNbug.mainserver.domain.user.entity.User;
+import org.codeNbug.mainserver.domain.user.repository.UserRepository;
+import org.codeNbug.mainserver.global.exception.globalException.DuplicateEmailException;
+import org.codeNbug.mainserver.global.exception.security.AuthenticationFailedException;
+import org.codeNbug.mainserver.global.util.JwtConfig;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtConfig jwtConfig;
+
+    /**
+     * 회원가입 서비스
+     *
+     * @param request 회원가입 요청 정보
+     * @return 회원가입 응답 정보
+     * @throws DuplicateEmailException 이메일이 이미 존재하는 경우 발생하는 예외
+     */
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateEmailException("이미 존재하는 이메일입니다.");
+        }
+
+        // 사용자 엔티티 생성 및 저장
+        User user = request.toEntity(passwordEncoder);
+        User savedUser = userRepository.save(user);
+
+        // 응답 반환
+        return SignupResponse.fromEntity(savedUser);
+    }
+
+    /**
+     * 로그인 서비스
+     *
+     * @param request 로그인 요청 정보
+     * @return 로그인 응답 정보 (JWT 토큰 포함)
+     * @throws AuthenticationFailedException 인증 실패 시 발생하는 예외
+     */
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new AuthenticationFailedException("이메일 또는 비밀번호가 올바르지 않습니다. 다시 확인해 주세요."));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new AuthenticationFailedException("이메일 또는 비밀번호가 올바르지 않습니다. 다시 확인해 주세요.");
+        }
+
+        // JWT 토큰 생성
+        String accessToken = jwtConfig.generateToken(user.getEmail());
+        String refreshToken = jwtConfig.generateToken(user.getEmail()); // 실제로는 다른 만료시간을 가진 토큰을 생성해야 함
+
+        // 응답 반환
+        return LoginResponse.of(accessToken, refreshToken);
+    }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/dto/RsData.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/dto/RsData.java
@@ -1,0 +1,46 @@
+package org.codeNbug.mainserver.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RsData<T> {
+    /**
+     * 응답 상태 코드 (예: "200-SUCCESS", "400-BAD_REQUEST")
+     * HTTP 상태 코드와 상세 코드를 포함
+     */
+    private String code;
+
+    /**
+     * 응답 메시지
+     * 사용자에게 표시할 메시지 또는 오류 설명
+     */
+    private String msg;
+
+    /**
+     * 응답 데이터
+     * API 응답에 포함될 실제 데이터 객체
+     */
+    private T data;
+
+    public RsData(String code, String msg) {
+        this(code, msg, null);
+    }
+
+    /**
+     * HTTP 상태 코드 추출
+     * code 문자열에서 첫 번째 부분을 추출하여 HTTP 상태 코드로 변환
+     *
+     * @return HTTP 상태 코드 (예: 200, 400, 500)
+     */
+    @JsonIgnore
+    public int getStatusCode() {
+        String statusCodeStr = code.split("-")[0];
+        return Integer.parseInt(statusCodeStr);
+    }
+
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/GlobalExceptionHandler.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,9 @@
 package org.codeNbug.mainserver.global.exception;
 
 import jakarta.validation.ConstraintViolationException;
-import org.codeNbug.mainserver.global.dto.ApiResponse;
 import org.codeNbug.mainserver.global.exception.globalException.DuplicateEmailException;
 import org.codeNbug.mainserver.global.exception.security.AuthenticationFailedException;
+import org.codeNbug.mainserver.global.dto.RsData;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -30,9 +30,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(DuplicateEmailException.class)
-    public ResponseEntity<ApiResponse<Object>> handleDuplicateEmailException(DuplicateEmailException e) {
+    public ResponseEntity<RsData<Object>> handleDuplicateEmailException(DuplicateEmailException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error(409, e.getMessage()));
+                .body(new RsData<>("409-CONFLICT", e.getMessage()));
     }
 
     /**
@@ -43,9 +43,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(AuthenticationFailedException.class)
-    public ResponseEntity<ApiResponse<Object>> handleAuthenticationFailedException(AuthenticationFailedException e) {
+    public ResponseEntity<RsData<Object>> handleAuthenticationFailedException(AuthenticationFailedException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.error(401, e.getMessage()));
+                .body(new RsData<>("401-UNAUTHORIZED", e.getMessage()));
     }
 
     /**
@@ -56,9 +56,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Object>> handleValidationExceptions(MethodArgumentNotValidException e) {
+    public ResponseEntity<RsData<Object>> handleValidationExceptions(MethodArgumentNotValidException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+                .body(new RsData<>("400-BAD_REQUEST", "데이터 형식이 잘못되었습니다."));
     }
 
     /**
@@ -69,9 +69,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(BindException.class)
-    public ResponseEntity<ApiResponse<Object>> handleBindException(BindException e) {
+    public ResponseEntity<RsData<Object>> handleBindException(BindException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+                .body(new RsData<>("400-BAD_REQUEST", "데이터 형식이 잘못되었습니다."));
     }
 
     /**
@@ -82,9 +82,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiResponse<Object>> handleConstraintViolationException(ConstraintViolationException e) {
+    public ResponseEntity<RsData<Object>> handleConstraintViolationException(ConstraintViolationException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+                .body(new RsData<>("400-BAD_REQUEST", "데이터 형식이 잘못되었습니다."));
     }
 
     /**
@@ -95,9 +95,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<ApiResponse<Object>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+    public ResponseEntity<RsData<Object>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(400, "필수 데이터가 누락되었습니다."));
+                .body(new RsData<>("400-BAD_REQUEST", "필수 데이터가 누락되었습니다."));
     }
 
     /**
@@ -108,9 +108,9 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    public ResponseEntity<RsData<Object>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+                .body(new RsData<>("400-BAD_REQUEST", "데이터 형식이 잘못되었습니다."));
     }
 
     /**
@@ -121,8 +121,8 @@ public class GlobalExceptionHandler {
      * @return API 응답
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Object>> handleAllExceptions(Exception e) {
+    public ResponseEntity<RsData<Object>> handleAllExceptions(Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(500, "서버 오류가 발생했습니다."));
+                .body(new RsData<>("500-INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."));
     }
 } 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/GlobalExceptionHandler.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,128 @@
+package org.codeNbug.mainserver.global.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.codeNbug.mainserver.global.dto.ApiResponse;
+import org.codeNbug.mainserver.global.exception.globalException.DuplicateEmailException;
+import org.codeNbug.mainserver.global.exception.security.AuthenticationFailedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+/**
+ * 글로벌 예외 처리 핸들러
+ * <p>
+ * 애플리케이션 전체에서 발생하는 예외를 처리하고 적절한 응답을 반환합니다.
+ * </p>
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * DuplicateEmailException 처리
+     * 이메일이 중복된 경우 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<ApiResponse<Object>> handleDuplicateEmailException(DuplicateEmailException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(409, e.getMessage()));
+    }
+
+    /**
+     * AuthenticationFailedException 처리
+     * 인증 실패 시 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(AuthenticationFailedException.class)
+    public ResponseEntity<ApiResponse<Object>> handleAuthenticationFailedException(AuthenticationFailedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(401, e.getMessage()));
+    }
+
+    /**
+     * MethodArgumentNotValidException 처리
+     * 요청 바디의 유효성 검사 실패 시 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+    }
+
+    /**
+     * BindException 처리
+     * 폼 데이터 바인딩 실패 시 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBindException(BindException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+    }
+
+    /**
+     * ConstraintViolationException 처리
+     * 제약 조건 위반 시 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleConstraintViolationException(ConstraintViolationException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+    }
+
+    /**
+     * MissingServletRequestParameterException 처리
+     * 필수 요청 파라미터가 누락된 경우 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(400, "필수 데이터가 누락되었습니다."));
+    }
+
+    /**
+     * MethodArgumentTypeMismatchException 처리
+     * 요청 파라미터의 타입이 맞지 않을 때 발생하는 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(400, "데이터 형식이 잘못되었습니다."));
+    }
+
+    /**
+     * 일반 예외 처리
+     * 위에서 처리되지 않은 모든 예외를 처리합니다.
+     *
+     * @param e 예외 객체
+     * @return API 응답
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleAllExceptions(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(500, "서버 오류가 발생했습니다."));
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/globalException/DuplicateEmailException.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/globalException/DuplicateEmailException.java
@@ -1,0 +1,10 @@
+package org.codeNbug.mainserver.global.exception.globalException;
+
+/**
+ * 이메일 중복 예외
+ */
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/security/AuthenticationFailedException.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/exception/security/AuthenticationFailedException.java
@@ -1,0 +1,10 @@
+package org.codeNbug.mainserver.global.exception.security;
+
+/**
+ * 인증 실패 예외
+ */
+public class AuthenticationFailedException extends RuntimeException {
+    public AuthenticationFailedException(String message) {
+        super(message);
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/config/SecurityConfig.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/config/SecurityConfig.java
@@ -105,6 +105,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         // 인증 없이 접근 가능한 경로 설정
+                        .requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()
                         // Swagger UI 관련 경로 허용

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/filter/JwtAuthenticationFilter.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/filter/JwtAuthenticationFilter.java
@@ -4,7 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.codeNbug.mainserver.global.security.config.JwtConfig;
+import org.codeNbug.mainserver.global.util.JwtConfig;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,10 +17,9 @@ import java.io.IOException;
 
 /**
  * JWT 인증 필터
- * <p>
- * 모든 HTTP 요청에 대해 JWT 토큰을 검증하고 인증 처리를 수행
+ *
+ * SecurityConfig에 정의된 경로에 해당하는 HTTP 요청에 대해 JWT 토큰을 검증하고 인증 처리를 수행
  * 요청 헤더에서 JWT 토큰을 추출하고 유효성을 검사한 후 Spring Security의 인증 컨텍스트에 사용자 정보를 설정
- * </p>
  */
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -40,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 모든 요청에 대해 실행되는 필터 메서드
+     * SecurityConfig에 정의된 경로에 해당하는 HTTP 요청에 대해 실행되는 필터 메서드
      * Authorization 헤더를 확인하여 JWT 토큰을 추출하고 인증을 처리
      * 유효한 토큰인 경우 Spring Security의 인증 컨텍스트에 사용자 정보를 설정
      * 
@@ -53,26 +52,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        
+
+        // Authorization 헤더에서 JWT 토큰을 포함한 값을 가져옴 (예: "Bearer <token>")
         final String authHeader = request.getHeader("Authorization");
         final String jwt;
         final String username;
 
+        // Authorization 헤더가 없거나 "Bearer "로 시작하지 않으면 인증 없이 다음 필터로 진행
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        jwt = authHeader.substring(7);
+        jwt = authHeader.substring(7); // JWT 토큰 부분만 추출
         username = jwtConfig.extractUsername(jwt);
 
+        // 사용자 이름이 존재하고, 현재 SecurityContext에 인증 정보가 없는 경우에만 인증 처리
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
-            
+
+            // JWT 토큰이 유효성 검증
             if (jwtConfig.validateToken(jwt)) {
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     userDetails, null, userDetails.getAuthorities());
-                
+
+                // 요청 정보를 기반으로 인증 토큰에 추가 세부 정보 설정 (예: IP 주소, 세션 정보) -> 필요할지도 몰라서 일단 선언해 놓음
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/service/CustomUserDetails.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/service/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package org.codeNbug.mainserver.global.security.service;
+
+import lombok.Getter;
+import org.codeNbug.mainserver.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * 스프링 시큐리티의 UserDetails 인터페이스 구현 클래스
+ */
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/service/CustomUserDetailsService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/service/CustomUserDetailsService.java
@@ -1,5 +1,8 @@
 package org.codeNbug.mainserver.global.security.service;
 
+import lombok.RequiredArgsConstructor;
+import org.codeNbug.mainserver.domain.user.entity.User;
+import org.codeNbug.mainserver.domain.user.repository.UserRepository;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -8,27 +11,32 @@ import org.springframework.stereotype.Service;
 
 /**
  * 커스텀 사용자 상세 정보 서비스
- * <p>
+
  * 스프링 시큐리티의 인증 메커니즘에서 사용자 정보를 로드하기 위한 서비스입니다.
  * 사용자 이름(username)을 기반으로 데이터베이스에서 사용자 정보를 조회하고
  * 스프링 시큐리티에서 사용할 수 있는 UserDetails 객체로 변환합니다.
- * </p>
  */
 @Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    /**
-     * 사용자 이름으로 사용자 상세 정보를 로드합니다.
+    private final UserRepository userRepository;
 
-     * 주어진 사용자 이름(username)을 기반으로 데이터베이스에서 사용자 정보를 조회하고,
+    /**
+     * 사용자 이름(이메일)으로 사용자 상세 정보를 로드합니다.
+     *
+     * 주어진 사용자 이름(이메일)을 기반으로 데이터베이스에서 사용자 정보를 조회하고,
      * 스프링 시큐리티에서 사용할 수 있는 UserDetails 객체로 변환하여 반환
      * 
-     * @param username 조회할 사용자의 이름(아이디)
+     * @param username 조회할 사용자의 이름(이메일)
      * @return 사용자 상세 정보를 포함한 UserDetails 객체
      * @throws UsernameNotFoundException 사용자를 찾을 수 없는 경우 발생하는 예외
      */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        throw new UsernameNotFoundException("username을 찾을 수 없습니다.: " + username);
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("이메일을 찾을 수 없습니다.: " + username));
+        
+        return new CustomUserDetails(user);
     }
 } 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/util/CookieUtil.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/util/CookieUtil.java
@@ -1,0 +1,29 @@
+package org.codeNbug.mainserver.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+    
+    public void setAccessTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie("accessToken", token);
+        setCommonCookieAttributes(cookie);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+
+    public void setRefreshTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie("refreshToken", token);
+        setCommonCookieAttributes(cookie);
+        cookie.setPath("/auth/refresh");
+        response.addCookie(cookie);
+    }
+
+    private void setCommonCookieAttributes(Cookie cookie) {
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
+    }
+} 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/util/JwtConfig.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/util/JwtConfig.java
@@ -1,4 +1,4 @@
-package org.codeNbug.mainserver.global.security.config;
+package org.codeNbug.mainserver.global.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -27,7 +27,7 @@ public class JwtConfig {
 
     /**
      * JWT 서명에 사용할 키를 생
-     * 
+     *
      * @return 서명용 암호화 키
      */
     private Key getSigningKey() {

--- a/service/main-server/src/main/resources/application.yml
+++ b/service/main-server/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
 
 # JWT Configuration
 jwt:
-  secret: ${jwt.secret:VGhpcyBpcyBhIHNlY3JldCBrZXkgdGhhdCBzaG91bGQgYmUgc3RvcmVkIHNlY3VyZWx5IHdpdGggYXQgbGVhc3QgMjU2IGJpdHM=}
+  secret: VGhpcyBpcyBhIHNlY3JldCBrZXkgdGhhdCBzaG91bGQgYmUgc3RvcmVkIHNlY3VyZWx5IHdpdGggYXQgbGVhc3QgMjU2IGJpdHM=
   expiration: 86400000 # 24 hours in milliseconds
 
 # CORS Configuration

--- a/service/main-server/src/main/resources/application.yml
+++ b/service/main-server/src/main/resources/application.yml
@@ -29,8 +29,8 @@ spring:
 
 # JWT Configuration
 jwt:
-  secret: VGhpcyBpcyBhIHNlY3JldCBrZXkgdGhhdCBzaG91bGQgYmUgc3RvcmVkIHNlY3VyZWx5IHdpdGggYXQgbGVhc3QgMjU2IGJpdHM=
-  expiration: 86400000 # 24 hours in milliseconds
+  secret: ${JWT_SECRET_KEY}
+  expiration: ${JWT_EXPIRATION_TIME}
 
 # CORS Configuration
 cors:

--- a/service/main-server/src/main/resources/application.yml
+++ b/service/main-server/src/main/resources/application.yml
@@ -27,6 +27,11 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
     open-in-view: false
 
+# JWT Configuration
+jwt:
+  secret: ${jwt.secret:VGhpcyBpcyBhIHNlY3JldCBrZXkgdGhhdCBzaG91bGQgYmUgc3RvcmVkIHNlY3VyZWx5IHdpdGggYXQgbGVhc3QgMjU2IGJpdHM=}
+  expiration: 86400000 # 24 hours in milliseconds
+
 # CORS Configuration
 cors:
   allowed-origins:


### PR DESCRIPTION
## 🔎 작업 내용
기본 로그인/회원가입 구현

- [x] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)
기본 로그인/회원가입 구현
- 현재, 로그인 시 refresh token과 access token이 동시에 같은 방법으로 생성되고 있음. 추후 수정 예정.
- sex, role과 같은 record data는 인가 기능을 구현하면서 enum으로 전환 예정
- JwtAuthenticationFilter > doFilterInternal에서 JWT 유효성 검증 중 유효한 토큰일 경우 요쳥 정보를 기반으로 인증 토큰에 추가 세부 정보를 설정하는 코드를 추가했음. 이 코드는 추후 필요 가능성을 예상한 코드이므로 상황에 따라 삭제 예정.
- 기본 로그인/회원가입 기능 테스트 완료


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
