### PR TITLE
Feat: RsData 응답 구조 확장 및 페이징 메타데이터 추가

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/dto/PageMetadata.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/dto/PageMetadata.java
@@ -1,0 +1,33 @@
+package org.codeNbug.mainserver.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+/**
+ * 페이징 처리된 응답에 포함될 메타데이터
+ */
+@Getter
+@Builder
+public class PageMetadata {
+    private int page;            // 현재 페이지 번호 (0-based)
+    private int size;            // 페이지 크기
+    private long totalElements;  // 전체 요소 수
+    private int totalPages;      // 전체 페이지 수
+    private boolean first;       // 첫 페이지 여부
+    private boolean last;        // 마지막 페이지 여부
+
+    /**
+     * Spring Data의 Page 객체로부터 PageMetadata 생성
+     */
+    public static <T> PageMetadata from(Page<T> page) {
+        return PageMetadata.builder()
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/dto/RsData.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/dto/RsData.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 @AllArgsConstructor
 @Getter
@@ -27,8 +28,22 @@ public class RsData<T> {
      */
     private T data;
 
+    /**
+     * 페이지 메타데이터 (페이징 처리된 응답에만 사용)
+     * null일 경우 JSON 응답에서 제외됨
+     */
+    private PageMetadata page;
+
+
     public RsData(String code, String msg) {
-        this(code, msg, null);
+        this(code, msg, null, null);
+    }
+
+    /**
+     * 데이터 포함 생성자 (페이징 없음)
+     */
+    public RsData(String code, String msg, T data) {
+        this(code, msg, data, null);
     }
 
     /**
@@ -41,6 +56,68 @@ public class RsData<T> {
     public int getStatusCode() {
         String statusCodeStr = code.split("-")[0];
         return Integer.parseInt(statusCodeStr);
+    }
+
+
+    /**
+     * 페이징 정보가 포함된 응답 생성
+     * Spring Data의 Page 객체로부터 데이터와 페이징 정보를 추출하여 응답 생성
+     *
+     * @param code 응답 코드 (예: "200-SUCCESS")
+     * @param msg 응답 메시지
+     * @param page 페이징 처리된 데이터
+     * @return 페이징 정보가 포함된 RsData 객체
+     */
+    public static <R> RsData<R> withPage(String code, String msg, Page<R> page) {
+        return new RsData<>(
+                code,
+                msg,
+                (R) page.getContent(),  // 페이지 내용을 데이터로 설정
+                PageMetadata.from(page) // 페이징 메타데이터 생성
+        );
+    }
+
+    /**
+     * 성공 응답 생성 - 페이징 포함 (코드: "200-SUCCESS")
+     *
+     * @param msg 성공 메시지
+     * @param page 페이징 처리된 데이터
+     * @return 성공 응답 객체
+     */
+    public static <R> RsData<R> successWithPage(String msg, Page<R> page) {
+        return withPage("200-SUCCESS", msg, page);
+    }
+
+    /**
+     * 일반적인 성공 응답 생성 (코드: "200-SUCCESS")
+     *
+     * @param msg 성공 메시지
+     * @param data 응답 데이터
+     * @return 성공 응답 객체
+     */
+    public static <R> RsData<R> success(String msg, R data) {
+        return new RsData<>("200-SUCCESS", msg, data);
+    }
+
+    /**
+     * 데이터 없는 성공 응답 생성 (코드: "200-SUCCESS")
+     *
+     * @param msg 성공 메시지
+     * @return 성공 응답 객체
+     */
+    public static <R> RsData<R> success(String msg) {
+        return new RsData<>("200-SUCCESS", msg);
+    }
+
+    /**
+     * 오류 응답 생성
+     *
+     * @param code 오류 코드 (예: "400-BAD_REQUEST")
+     * @param msg 오류 메시지
+     * @return 오류 응답 객체
+     */
+    public static <R> RsData<R> error(String code, String msg) {
+        return new RsData<>(code, msg);
     }
 
 }


### PR DESCRIPTION
## 🔎 작업 내용
- RsData 응답 포맷을 확장하여, 페이징 정보를 함께 반환할 수 있도록 변경했습니다.
- PageMetadata 클래스를 별도로 생성하여, 페이지네이션 관련 메타데이터를 관리합니다.

- [X] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)
기존 API (`code`, `msg`, `data`) 응답은 유지.
페이징 처리가 필요한 API에서는 선택적으로 page 정보를 포함하여 응답할 수 있습니다.
### 📷 스크린샷 (선택)
없음


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
