### PR TITLE
Feat: 이벤트 신규 등록 기능 구현 및 좌석/좌석등급/레이아웃 저장 로직 개선

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/controller/ManagerController.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/controller/ManagerController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.codeNbug.mainserver.domain.manager.dto.EventRegisterRequest;
 import org.codeNbug.mainserver.domain.manager.dto.EventRegisterResponse;
 import org.codeNbug.mainserver.domain.manager.service.ManagerService;
+import org.codeNbug.mainserver.global.dto.RsData;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,9 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class ManagerController {
     private final ManagerService managerService;
 
+    /**
+     * 이벤트 등록 API
+     * @param request 이벤트 등록 요청 DTO
+     * @return 성공 시 RsData<EventRegisterResponse> 포맷으로 응답
+     */
     @PostMapping
-    public ResponseEntity<EventRegisterResponse> eventRegister(@RequestBody EventRegisterRequest request) {
-        EventRegisterResponse response = managerService.eventRegister(request);
-        return null;
+    public ResponseEntity<RsData<EventRegisterResponse>> eventRegister(@RequestBody EventRegisterRequest request) {
+        EventRegisterResponse response = managerService.registerEvent(request);
+        return ResponseEntity.ok(RsData.success("이벤트 등록 성공", response));
     }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/EventRegisterRequest.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/EventRegisterRequest.java
@@ -1,6 +1,8 @@
 package org.codeNbug.mainserver.domain.manager.dto;
 
 import lombok.*;
+import org.codeNbug.mainserver.domain.manager.dto.layout.LayoutDto;
+import org.codeNbug.mainserver.domain.manager.dto.layout.PriceDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,35 +23,10 @@ public class EventRegisterRequest {
     private String location;
     private String hallName;
     private int seatCount;
-    private Layout layout;
-    private List<Price> price;
+    private LayoutDto layout;
+    private List<PriceDto> price;
     private LocalDateTime bookingStart;
     private LocalDateTime bookingEnd;
     private int agelimit;
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Layout {
-        private List<List<String>> layout; // 좌석 배치 (2차원 배열 구조)
-        private Map<String, SeatInfo> seat; // 좌석 상세 정보
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SeatInfo {
-        private String grade; // 좌석 등급 (예: A, S 등)
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Price {
-        private String grade; // 좌석 등급
-        private int amount;   // 가격
-    }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/EventRegisterResponse.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/EventRegisterResponse.java
@@ -1,6 +1,8 @@
 package org.codeNbug.mainserver.domain.manager.dto;
 
 import lombok.*;
+import org.codeNbug.mainserver.domain.manager.dto.layout.LayoutDto;
+import org.codeNbug.mainserver.domain.manager.dto.layout.PriceDto;
 import org.codeNbug.mainserver.domain.manager.entity.EventStatusEnum;
 
 import java.time.LocalDateTime;
@@ -23,8 +25,8 @@ public class EventRegisterResponse {
     private String location;
     private String hallName;
     private int seatCount;
-    private Layout layout;
-    private List<Price> price;
+    private LayoutDto layout;
+    private List<PriceDto> price;
     private LocalDateTime bookingStart;
     private LocalDateTime bookingEnd;
     private int agelimit;
@@ -32,29 +34,4 @@ public class EventRegisterResponse {
     private LocalDateTime modifiedAt;
     private EventStatusEnum status;
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Layout {
-        private List<List<String>> layout;
-        private Map<String, SeatInfo> seat;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SeatInfo {
-        private String grade;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Price {
-        private String grade;
-        private int amount;
-    }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/layout/LayoutDto.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/layout/LayoutDto.java
@@ -1,0 +1,18 @@
+package org.codeNbug.mainserver.domain.manager.dto.layout;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LayoutDto {
+    private List<List<String>> layout; // 2차원 좌석 배치 (ex: A1, A2, B1...)
+    private Map<String, SeatInfoDto> seat; // 좌석 이름 -> 좌석 정보
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/layout/PriceDto.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/layout/PriceDto.java
@@ -1,0 +1,14 @@
+package org.codeNbug.mainserver.domain.manager.dto.layout;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PriceDto {
+    private String grade; // 좌석 등급 (ex: S, A 등)
+    private int amount;   // 가격 (ex: 50000)
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/layout/SeatInfoDto.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/layout/SeatInfoDto.java
@@ -1,0 +1,14 @@
+package org.codeNbug.mainserver.domain.manager.dto.layout;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatInfoDto {
+    private String grade; // 예: "S", "A" 등급
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/entity/Event.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/entity/Event.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @Table(name = "event")
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Event {
 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/entity/EventType.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/entity/EventType.java
@@ -1,9 +1,6 @@
 package org.codeNbug.mainserver.domain.manager.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,5 +14,6 @@ public class EventType {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long eventTypeId;
 
+    @Column(nullable = false, unique = true)
     private String name;
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/repository/EventTypeRepository.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/repository/EventTypeRepository.java
@@ -3,5 +3,8 @@ package org.codeNbug.mainserver.domain.manager.repository;
 import org.codeNbug.mainserver.domain.manager.entity.EventType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EventTypeRepository extends JpaRepository<EventType, Long> {
+    Optional<EventType> findByName(String name);
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/ManagerService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/ManagerService.java
@@ -1,17 +1,181 @@
 package org.codeNbug.mainserver.domain.manager.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.codeNbug.mainserver.domain.manager.dto.EventRegisterRequest;
 import org.codeNbug.mainserver.domain.manager.dto.EventRegisterResponse;
+import org.codeNbug.mainserver.domain.manager.dto.layout.LayoutDto;
+import org.codeNbug.mainserver.domain.manager.dto.layout.PriceDto;
+import org.codeNbug.mainserver.domain.manager.dto.layout.SeatInfoDto;
+import org.codeNbug.mainserver.domain.manager.entity.Event;
+import org.codeNbug.mainserver.domain.manager.entity.EventStatusEnum;
+import org.codeNbug.mainserver.domain.manager.entity.EventType;
 import org.codeNbug.mainserver.domain.manager.repository.EventRepository;
+import org.codeNbug.mainserver.domain.manager.repository.EventTypeRepository;
+import org.codeNbug.mainserver.domain.seat.entity.Seat;
+import org.codeNbug.mainserver.domain.seat.entity.SeatGrade;
+import org.codeNbug.mainserver.domain.seat.entity.SeatGradeEnum;
+import org.codeNbug.mainserver.domain.seat.entity.SeatLayout;
+import org.codeNbug.mainserver.domain.seat.repository.SeatGradeRepository;
+import org.codeNbug.mainserver.domain.seat.repository.SeatLayoutRepository;
+import org.codeNbug.mainserver.domain.seat.repository.SeatRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class ManagerService {
-    private final EventRepository eventRepository;
 
-    public EventRegisterResponse eventRegister(EventRegisterRequest request) {
-        return null;
+    private final EventRepository eventRepository;
+    private final EventTypeRepository eventTypeRepository;
+    private final SeatLayoutRepository seatLayoutRepository;
+    private final SeatGradeRepository seatGradeRepository;
+    private final SeatRepository seatRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 이벤트 등록 메인 메서드
+     */
+    @Transactional
+    public EventRegisterResponse registerEvent(EventRegisterRequest request) {
+        EventType eventType = findOrCreateEventType(request.getType());
+        Event event = createAndSaveEvent(request, eventType);
+        SeatLayout seatLayout = createAndSaveSeatLayout(request, event);
+        Map<String, SeatGrade> seatGradeMap = createAndSaveSeatGrades(request, event);
+        createAndSaveSeats(request, event, seatLayout, seatGradeMap);
+        return buildEventRegisterResponse(request, event);
+    }
+
+    /**
+     * 타입명으로 EventType을 조회하고 없으면 생성
+     */
+    private EventType findOrCreateEventType(String typeName) {
+        return eventTypeRepository.findByName(typeName)
+                .orElseGet(() -> eventTypeRepository.save(new EventType(null, typeName)));
+    }
+
+    /**
+     * Event 생성 및 저장
+     */
+    private Event createAndSaveEvent(EventRegisterRequest request, EventType eventType) {
+        Event event = new Event(
+                null,
+                eventType.getEventTypeId(),
+                request.getTitle(),
+                request.getThumbnailUrl(),
+                request.getDescription(),
+                request.getAgelimit(),
+                request.getRestriction(),
+                request.getSeatCount(),
+                request.getBookingStart(),
+                request.getBookingEnd(),
+                request.getStartDate(),
+                request.getEndDate(),
+                0,
+                request.getLocation(),
+                request.getHallName(),
+                null,
+                null,
+                EventStatusEnum.OPEN,
+                true
+        );
+        return eventRepository.save(event);
+    }
+
+    /**
+     * SeatLayout 생성 및 저장
+     */
+    private SeatLayout createAndSaveSeatLayout(EventRegisterRequest request, Event event) {
+        try {
+            String layoutJson = objectMapper.writeValueAsString(request.getLayout());
+            SeatLayout seatLayout = new SeatLayout(
+                    null,
+                    layoutJson,
+                    event
+            );
+            return seatLayoutRepository.save(seatLayout);
+        } catch (Exception e) {
+            throw new RuntimeException("Seat layout 직렬화 실패", e);
+        }
+    }
+
+    /**
+     * SeatGrade 생성 및 저장
+     */
+    private Map<String, SeatGrade> createAndSaveSeatGrades(EventRegisterRequest request, Event event) {
+        Map<String, SeatGrade> seatGradeMap = new HashMap<>();
+        for (PriceDto price : request.getPrice()) {
+            SeatGrade seatGrade = new SeatGrade(
+                    null,
+                    SeatGradeEnum.valueOf(price.getGrade()),
+                    price.getAmount(),
+                    event
+            );
+            SeatGrade savedGrade = seatGradeRepository.save(seatGrade);
+            seatGradeMap.put(price.getGrade(), savedGrade);
+        }
+        return seatGradeMap;
+    }
+
+    /**
+     * Seat 개별 생성 및 저장
+     */
+    private void createAndSaveSeats(EventRegisterRequest request, Event event, SeatLayout seatLayout, Map<String, SeatGrade> seatGradeMap) {
+        LayoutDto layoutDto = request.getLayout();
+        for (List<String> row : layoutDto.getLayout()) {
+            for (String seatName : row) {
+                if (seatName == null) continue;
+
+                SeatInfoDto seatInfo = layoutDto.getSeat().get(seatName);
+                if (seatInfo == null) {
+                    throw new IllegalStateException("SeatInfo not found for seat: " + seatName);
+                }
+
+                SeatGrade seatGrade = seatGradeMap.get(seatInfo.getGrade());
+                if (seatGrade == null) {
+                    throw new IllegalStateException("SeatGrade not found for grade: " + seatInfo.getGrade());
+                }
+
+                Seat seat = new Seat(
+                        null,
+                        seatName,
+                        true,
+                        seatGrade,
+                        seatLayout,
+                        null,
+                        event
+                );
+                seatRepository.save(seat);
+            }
+        }
+    }
+
+    /**
+     * 최종 응답 객체 생성
+     */
+    private EventRegisterResponse buildEventRegisterResponse(EventRegisterRequest request, Event event) {
+        return EventRegisterResponse.builder()
+                .eventId(event.getEventId())
+                .title(event.getTitle())
+                .type(request.getType())
+                .description(request.getDescription())
+                .restriction(request.getRestriction())
+                .thumbnailUrl(event.getThumbnailUrl())
+                .startDate(event.getEventStart())
+                .endDate(event.getEventEnd())
+                .location(event.getLocation())
+                .hallName(event.getHallName())
+                .seatCount(event.getSeatCount())
+                .layout(request.getLayout())
+                .price(request.getPrice())
+                .bookingStart(event.getBookingStart())
+                .bookingEnd(event.getBookingEnd())
+                .agelimit(event.getAgeLimit())
+                .createdAt(event.getCreatedAt())
+                .modifiedAt(event.getModifiedAt())
+                .status(event.getStatus())
+                .build();
     }
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/Seat.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/Seat.java
@@ -44,7 +44,7 @@ public class Seat {
 	@JoinColumn(name = "layout_id", nullable = false)
 	private SeatLayout layout;
 
-	@OneToOne
+	@ManyToOne
 	@JoinColumn(name = "ticket_id")
 	private Ticket ticketId;
 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/SeatGrade.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/entity/SeatGrade.java
@@ -28,6 +28,7 @@ public class SeatGrade {
 
 	@Enumerated(EnumType.STRING)
 	private SeatGradeEnum grade;
+
 	private Integer amount;
 
 	@ManyToOne

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/repository/SeatRepository.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/repository/SeatRepository.java
@@ -8,8 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
-	List<Seat> findAllByLayout(Long layoutId);
-
 	@Query("SELECT s FROM Seat s JOIN FETCH s.gradeId WHERE s.layout.id = :layoutId ORDER BY s.location ASC")
 	List<Seat> findAllByLayoutIdWithGrade(@Param("layoutId") Long layoutId);
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/config/SecurityConfig.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/security/config/SecurityConfig.java
@@ -111,6 +111,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/public/**").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/manager/**").permitAll()
                         // 나머지 경로는 인증 필요
                         .anyRequest().authenticated())
                 .authenticationProvider(authenticationProvider())

--- a/service/main-server/src/main/resources/application.yml
+++ b/service/main-server/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     password: ${db.password}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
## 🔎 작업 내용
신규 이벤트 등록

- [x] ⚡️ 새로운 기능 추가
- [x] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명
📌 작업 개요
이벤트(공연/전시 등) 신규 등록 기능을 구현했습니다.

이벤트 등록 시 좌석 레이아웃, 좌석 정보(Seat), 좌석 등급(SeatGrade)까지 함께 저장하는 로직을 작성했습니다.

📌 주요 변경 사항
Event 등록

요청 데이터(EventRegisterRequest)를 받아 새로운 이벤트를 생성하고 저장.

요청에 포함된 타입(type)이 존재하지 않으면 새로운 EventType을 생성하고 사용.

SeatLayout 저장

좌석 레이아웃(LayoutDto)을 JSON 문자열로 변환해 SeatLayout 엔티티로 저장.

SeatLayout은 이벤트별로 1:1 매핑되도록 설계.

SeatGrade 저장

공연마다 좌석 등급별 가격이 다를 수 있어, 이벤트별로 SeatGrade를 생성하여 저장.

SeatGradeEnum (VIP, R, S, A, B, STANDING)을 기반으로 좌석 등급을 관리.

Seat 저장

좌석 이름(A1, B2 등)을 기반으로 Seat 엔티티 생성.

각 좌석은 SeatGrade, SeatLayout, Event와 매핑하여 저장.

좌석은 처음 생성 시 예약 가능 상태(available=true)로 등록.

Seat과 Ticket 관계 수정

기존 @OneToOne → @ManyToOne으로 수정하여, 좌석당 티켓 연결에 Unique 제약이 발생하지 않도록 변경.

이로 인해 좌석 등록 시 "Duplicate entry" 에러를 해결함.

응답 구조 통일

모든 API 응답은 ResponseEntity<RsData<>> 형태로 통일.

성공/실패를 명확히 코드(200-SUCCESS, 400-FAIL 등)와 함께 반환.

📌 고민했던 점
SeatLayout을 여러 이벤트가 공유하는 구조 대신, 이벤트마다 별도의 SeatLayout을 가지도록 설계했습니다.

SeatGrade는 공연마다 가격이 다를 수 있어 Event별 SeatGrade를 따로 저장하게 했습니다.

Seat과 Ticket의 관계 설정을 고민하다가, 예약되지 않은 좌석이 존재할 수 있다는 점을 고려해 @ManyToOne 매핑을 채택했습니다.

📌 테스트
Postman을 통해 이벤트 등록 API 정상 동작 확인

100개 이상의 좌석이 포함된 공연 등록 테스트 성공

DB에 이벤트, 좌석 레이아웃, 좌석 등급, 좌석들이 정상적으로 저장되는 것 확인

📸 참고: ERD 변경 요약
Event → SeatLayout 1:1

Event → SeatGrade 1:N

SeatLayout → Seat 1:N

Seat → Ticket N:1


### 📷 스크린샷
![image](https://github.com/user-attachments/assets/87205893-8fd8-48e9-a45e-f232d97fc641)



### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
