### PR TITLE
refactor: 매니저의 행사 조회에서 Dto 에 삭제 유무 확인할 수 있는 필드 추가

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/ManagerEventListResponse.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/ManagerEventListResponse.java
@@ -21,4 +21,5 @@ public class ManagerEventListResponse {
     private LocalDateTime endDate;
     private String location;
     private String hallName;
+    private Boolean isDeleted;
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/ManagerEventSearchService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/ManagerEventSearchService.java
@@ -18,8 +18,6 @@ import java.util.List;
 public class ManagerEventSearchService {
 
     private final ManagerEventRepository managerEventRepository;
-    private final UserRepository userRepository;
-    private final EventRepository eventRepository;
     private final EventTypeRepository eventTypeRepository;
 
 
@@ -41,6 +39,7 @@ public class ManagerEventSearchService {
                         .endDate(event.getInformation().getEventEnd())
                         .location(event.getInformation().getLocation())
                         .hallName(event.getInformation().getHallName())
+                        .isDeleted(event.getIsDeleted())
                         .build())
                 .toList();
 


### PR DESCRIPTION
## 🔎 작업 내용
매니저가 행사를 조회할때 삭제된 행사를 확인할 수 있는 isDeleted 필드를 응답 Dto 에 포함하도록 변경

- [ ] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명
매니저가 행사를 조회할때 삭제된 행사를 확인할 수 있는 isDeleted 필드를 응답 Dto 에 포함하도록 변경

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d9b70ebe-6a25-4586-8127-1a579ce0e18f)



### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
