### PR TITLE
feat: 서버마다 stream consumer group으로 맞는 메시지 가져오기

### DIFF
--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/redis/RedisConfig.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/redis/RedisConfig.java
@@ -29,7 +29,7 @@ public class RedisConfig {
 	// dispatch queue의 컨슈머 그룹명
 	public static final String ENTRY_QUEUE_CONSUMER_NAME = "ENTRY_QUEUE_CONSUMER";
 	public static final String DISPATCH_QUEUE_CHANNEL_NAME = "DISPATCH";
-	public static final Long ENTRY_QUEUE_CAPACITY = 1000L;
+	public static final Integer ENTRY_QUEUE_CAPACITY = 1000;
 	public static final String WAITING_QUEUE_IN_USER_RECORD_KEY_NAME = "WAITING_USER_ID";
 
 	@Bean

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
@@ -47,7 +47,7 @@ public class EntryPromoteThread {
 				// waiting queue message에서 userId, eventId, instanceId 추출
 				Long userId = Long.parseLong(record.getValue().get("userId").toString());
 				Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
-				String instanceId = record.getValue().get("instanceId").toString();
+				String instanceId = String.valueOf(record.getValue().get("instanceId"));
 
 				// entry queue message를 생성
 				redisTemplate.opsForStream()

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryQueueConsumer.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryQueueConsumer.java
@@ -37,11 +37,16 @@ public class EntryQueueConsumer {
 	private void handleMessage(MapRecord<String, String, String> record) {
 		Map<String, String> body = record.getValue();
 		// 1) 메시지 처리 로직
-		redisTemplate.convertAndSend(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, Map.of(
-			"userId", body.get("userId"),
-			"eventId", body.get("eventId"),
-			"instanceId", body.get("instanceId")
-		));
+		String userId = body.get("userId");
+		String eventId = body.get("eventId");
+		String instanceId = body.get("instanceId").substring(1, body.get("instanceId").length() - 1);
+
+		redisTemplate.opsForStream()
+			.add(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, Map.of(
+				"userId", Long.parseLong(userId),
+				"eventId", Long.parseLong(eventId),
+				"instanceId", instanceId)
+			);
 		// 2) ACK
 		redisTemplate.opsForStream()
 			.acknowledge(RedisConfig.ENTRY_QUEUE_KEY_NAME, RedisConfig.ENTRY_QUEUE_GROUP_NAME, record.getId());

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/EntryStreamMessageListener.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/EntryStreamMessageListener.java
@@ -1,0 +1,133 @@
+package org.codeNbug.queueserver.external.redis;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.codeNbug.queueserver.entryauth.service.EntryAuthService;
+import org.codeNbug.queueserver.waitingqueue.entity.SseConnection;
+import org.codeNbug.queueserver.waitingqueue.entity.Status;
+import org.codeNbug.queueserver.waitingqueue.service.SseEmitterService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.stream.StreamListener;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class EntryStreamMessageListener implements StreamListener<String, MapRecord<String, String, String>> {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisConnectionFactory redisConnectionFactory;
+	private final SseEmitterService sseEmitterService;
+	private final EntryAuthService entryAuthService;
+
+	@Value("${custom.instance-id}")
+	private String instanceId;
+
+	private String groupName = RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME + ":" + instanceId;
+	private String consumerName = instanceId + "-consumer"; // 각 인스턴스마다 고유한 컨슈머 이름
+
+	private StreamMessageListenerContainer<String, MapRecord<String, String, String>> streamMessageListenerContainer;
+
+	public EntryStreamMessageListener(RedisTemplate<String, Object> redisTemplate,
+		RedisConnectionFactory redisConnectionFactory, SseEmitterService sseEmitterService,
+		EntryAuthService entryAuthService) {
+		this.redisTemplate = redisTemplate;
+		this.redisConnectionFactory = redisConnectionFactory;
+		this.sseEmitterService = sseEmitterService;
+		this.entryAuthService = entryAuthService;
+	}
+
+	@PostConstruct
+	public void startListening() {
+
+		// 컨슈머 그룹 생성 (이미 RedisConfig의 basicRedisTemplate 빈에서 시도함)
+		try {
+			// 스트림이 존재하지 않으면 BUSYGROUP 에러가 발생할 수 있으므로 확인
+			if (redisTemplate.opsForStream().groups(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME).stream()
+				.noneMatch(xInfoGroup -> xInfoGroup.groupName().equals(groupName))) {
+				redisTemplate.opsForStream().createGroup(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, groupName);
+			}
+		} catch (RedisSystemException e) {
+			redisTemplate.opsForStream().createGroup(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, groupName);
+		}
+
+		StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+			StreamMessageListenerContainer.StreamMessageListenerContainerOptions
+				.builder()
+				.pollTimeout(Duration.ofSeconds(1)) // 폴링 타임아웃 설정
+				.batchSize(RedisConfig.ENTRY_QUEUE_CAPACITY) // 한 번에 가져올 메시지 수
+				.build();
+
+		streamMessageListenerContainer = StreamMessageListenerContainer.create(redisConnectionFactory, options);
+
+		// '>'는 아직 처리되지 않은 새로운 메시지만 읽겠다는 의미
+		// ReadOffset.lastConsumed()는 현재 컨슈머 그룹에서 마지막으로 처리(ack)한 메시지 다음부터 읽음
+		streamMessageListenerContainer.receive(
+			Consumer.from(groupName, consumerName),
+			StreamOffset.create(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, ReadOffset.lastConsumed()),
+			this // 리스너로 현재 클래스 인스턴스 지정
+		);
+
+		streamMessageListenerContainer.start();
+		log.info("Started listening to Redis Stream '{}' with consumer group '{}' and consumer name '{}'",
+			RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, groupName, consumerName);
+	}
+
+	@PreDestroy
+	public void stopListening() {
+		if (streamMessageListenerContainer != null) {
+			streamMessageListenerContainer.stop();
+			log.info("Stopped listening to Redis Stream.");
+		}
+	}
+
+	@Override
+	public void onMessage(MapRecord<String, String, String> message) {
+		Map<String, String> body = message.getValue();
+
+		Long userId = Long.parseLong(body.get("userId"));
+		Long eventId = Long.parseLong(body.get("eventId"));
+		SseConnection sseConnection = sseEmitterService.getEmitterMap().get(userId);
+
+		if (sseConnection == null || !sseConnection.getEventId().equals(eventId)) {
+			return;
+		}
+
+		sseConnection.setStatus(Status.IN_ENTRY);
+		SseEmitter emitter = sseConnection.getEmitter();
+
+		String token = entryAuthService.generateEntryAuthToken(Map.of("eventId", eventId, "userId", userId),
+			"entryAuthToken");
+		redisTemplate.opsForHash()
+			.put(RedisConfig.ENTRY_TOKEN_STORAGE_KEY_NAME, userId.toString(), token);
+		try {
+
+			emitter.send(
+				SseEmitter.event()
+					.data(Map.of(
+						"eventId", eventId,
+						"userId", userId,
+						"status", sseConnection.getStatus(),
+						"token", token
+					))
+			);
+			redisTemplate.opsForStream()
+				.acknowledge(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME, groupName, message.getId());
+		} catch (Exception e) {
+			emitter.complete();
+		}
+	}
+}

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/RedisConfig.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/RedisConfig.java
@@ -7,9 +7,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.PatternTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -20,7 +17,7 @@ public class RedisConfig {
 	public static final String WAITING_QUEUE_GROUP_NAME = "WAITING_QUEUE";
 	// waiting queue redis stream 키 이름
 	public static final String WAITING_QUEUE_KEY_NAME = "WAITING";
-	public static final Long ENTRY_QUEUE_CAPACITY = 1000L;
+	public static final Integer ENTRY_QUEUE_CAPACITY = 1000;
 	// 메시지의 idx 값을 저장하기 위한 space의 key값
 	public static final String WAITING_QUEUE_IDX_KEY_NAME = "WAITING_QUEUE_IDX";
 	// entry queue의 현재 인원을  저장하기 위한 space의 key값
@@ -32,9 +29,10 @@ public class RedisConfig {
 	public static final String QUEUE_MESSAGE_INSTANCE_ID_KEY_NAME = "instanceId";
 	// 메시지 내부의 idx 속성의 키 값
 	public static final String QUEUE_MESSAGE_IDX_KEY_NAME = "idx";
-	private static final String DISPATCH_QUEUE_CHANNEL_NAME = "DISPATCH";
+	public static final String DISPATCH_QUEUE_CHANNEL_NAME = "DISPATCH";
 	public static final String WAITING_QUEUE_IN_USER_RECORD_KEY_NAME = "WAITING_USER_ID";
 	public static final String ENTRY_TOKEN_STORAGE_KEY_NAME = "ENTRY_TOKEN";
+	private static final String ENTRY_USER_STREAM_GROUP = "ENTRY_CONSUMER_GROUP";
 
 	@Value("${custom.instance-id}")
 	private String instanceId;
@@ -91,23 +89,4 @@ public class RedisConfig {
 		}
 		return redisTemplate;
 	}
-
-	@Bean
-	public RedisMessageListenerContainer redisMessageListenerContainer(
-		@Qualifier("pubSubConnectionFactory") LettuceConnectionFactory cf,
-		MessageListenerAdapter listenerAdapter) {
-		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-		container.setConnectionFactory(cf);
-		// 구독할 채널을 등록
-		container.addMessageListener(listenerAdapter, new PatternTopic(RedisConfig.DISPATCH_QUEUE_CHANNEL_NAME));
-		// container.start();
-		return container;
-	}
-
-	@Bean
-	public MessageListenerAdapter listenerAdapter(Subscriber subscriber) {
-		// "onMessage" 메소드가 호출됩니다.
-		return new MessageListenerAdapter(subscriber, "onMessage");
-	}
-
 }

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/Subscriber.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/Subscriber.java
@@ -11,13 +11,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@Component
+// @Component
 public class Subscriber implements MessageListener {
 
 	private final ObjectMapper objectMapper;


### PR DESCRIPTION
## 🔎 작업 내용
기존 pub/sub으로 메시지를 queue server로 전송하던 것을 서버 인스턴스마다 consumer group으로 가져오도록 수정했습니다.

- [x] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)

### 📷 스크린샷 (선택)
없음


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
