### PR TITLE
Bug: orderId null 수정

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/purchase/entity/Purchase.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/purchase/entity/Purchase.java
@@ -68,12 +68,14 @@ public class Purchase {
 
 	public void updatePaymentInfo(
 		String paymentUuid,
+		String orderId,
 		int amount,
 		PaymentMethodEnum paymentMethod,
 		String orderName,
 		LocalDateTime purchaseDate
 	) {
 		this.paymentUuid = paymentUuid;
+		this.orderId = orderId;
 		this.amount = amount;
 		this.paymentMethod = paymentMethod;
 		this.orderName = orderName;

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/purchase/service/PurchaseService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/purchase/service/PurchaseService.java
@@ -122,6 +122,7 @@ public class PurchaseService {
 
 		purchase.updatePaymentInfo(
 			info.getPaymentKey(),
+			info.getOrderId(),
 			info.getTotalAmount(),
 			methodEnum,
 			event.getSeatSelectable() ? "지정석 %d매".formatted(seatIds.size()) :


### PR DESCRIPTION
## 🔎 작업 내용
purchase table에 orderId가 null로 삽입되는 버그 수정

- [ ] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)
없음
### 📷 스크린샷 (선택)
<img width="973" alt="image" src="https://github.com/user-attachments/assets/a70435f9-1359-40f4-9fb5-9aadd53d87bb" />


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
