### PR TITLE
Fix: 실패 메세지의 인코딩 문제로 인한 텍스트 깨짐 현상 해결(SecurityConfig와 .yml에 모두 선언)

### DIFF
--- a/service/main-server/src/main/resources/application.yml
+++ b/service/main-server/src/main/resources/application.yml
@@ -1,5 +1,10 @@
 server:
   port: 9000
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+      enabled: true
 
 spring:
   profiles:

--- a/service/user/src/main/java/org/codenbug/user/security/config/SecurityConfig.java
+++ b/service/user/src/main/java/org/codenbug/user/security/config/SecurityConfig.java
@@ -129,12 +129,12 @@ public class SecurityConfig {
 			.exceptionHandling(exceptionHandling -> exceptionHandling
 				.authenticationEntryPoint((request, response, authException) -> {
 					response.setStatus(HttpStatus.UNAUTHORIZED.value());
-					response.setContentType("application/json");
+					response.setContentType("application/json;charset=UTF-8");
 					response.getWriter().write("{\"code\":\"401-UNAUTHORIZED\",\"msg\":\"인증 정보가 필요합니다.\"}");
 				})
 				.accessDeniedHandler((request, response, accessDeniedException) -> {
 					response.setStatus(HttpStatus.FORBIDDEN.value());
-					response.setContentType("application/json");
+					response.setContentType("application/json;charset=UTF-8");
 					response.getWriter().write("{\"code\":\"403-FORBIDDEN\",\"msg\":\"접근 권한이 없습니다.\"}");
 				}))
 			.authenticationProvider(authenticationProvider())


### PR DESCRIPTION
## 🔎 작업 내용
실패 메세지의 인코딩 문제로 인한 텍스트 깨짐 현상 해결(SecurityConfig와 .yml에 모두 선언)

- [ ] ⚡️ 새로운 기능 추가
- [x] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
