### PR TITLE
Feat/알림 트리거 통합

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/EventDeleteService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/EventDeleteService.java
@@ -1,8 +1,15 @@
 package org.codeNbug.mainserver.domain.manager.service;
 
+import java.util.List;
+
 import org.codeNbug.mainserver.domain.event.entity.Event;
+import org.codeNbug.mainserver.domain.event.entity.EventStatusEnum;
 import org.codeNbug.mainserver.domain.manager.repository.EventRepository;
 import org.codeNbug.mainserver.domain.manager.repository.ManagerEventRepository;
+import org.codeNbug.mainserver.domain.notification.entity.NotificationEnum;
+import org.codeNbug.mainserver.domain.notification.service.NotificationService;
+import org.codeNbug.mainserver.domain.purchase.entity.Purchase;
+import org.codeNbug.mainserver.domain.purchase.repository.PurchaseRepository;
 import org.codeNbug.mainserver.global.exception.globalException.BadRequestException;
 import org.codenbug.user.domain.user.entity.User;
 import org.codenbug.user.domain.user.repository.UserRepository;
@@ -10,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventDeleteService {
@@ -18,6 +27,8 @@ public class EventDeleteService {
     private final EventRepository eventRepository;
     private final UserRepository userRepository;
     private final ManagerEventRepository managerEventRepository;
+    private final NotificationService notificationService;
+    private final PurchaseRepository purchaseRepository;
 
     /**
      * 이벤트를 삭제 처리하는 메서드입니다.
@@ -30,7 +41,40 @@ public class EventDeleteService {
     public void deleteEvent(Long eventId, Long managerId) {
         Event event = getEventOrThrow(eventId);
         validateManagerAuthority(managerId, event);
+
+        // 이벤트 상태 변경
         event.setIsDeleted(true);
+        event.setStatus(EventStatusEnum.CANCELLED);
+
+        // 알림 처리는 메인 로직과 분리하여 예외 처리
+        try {
+            // 해당 이벤트 구매자들 조회
+            List<Purchase> purchases = purchaseRepository.findAllByEventId(eventId);
+
+            // 모든 구매자에게 행사 취소 알림 전송
+            String notificationContent = String.format(
+                    "[%s] 행사가 취소되었습니다. 예매 내역을 확인해주세요.",
+                    event.getInformation().getTitle()
+            );
+
+            for (Purchase purchase : purchases) {
+                try {
+                    Long userId = purchase.getUser().getUserId();
+                    notificationService.createNotification(
+                            userId,
+                            NotificationEnum.EVENT,
+                            notificationContent
+                    );
+                } catch (Exception e) {
+                    log.error("행사 취소 알림 전송 실패. 사용자ID: {}, 구매ID: {}, 오류: {}",
+                            purchase.getUser().getUserId(), purchase.getId(), e.getMessage(), e);
+                    // 개별 사용자 알림 실패는 다른 사용자 알림이나 이벤트 취소에 영향을 주지 않음
+                }
+            }
+        } catch (Exception e) {
+            log.error("행사 취소 알림 처리 실패. 이벤트ID: {}, 오류: {}", eventId, e.getMessage(), e);
+            // 알림 전체 실패는 이벤트 취소에 영향을 주지 않도록 예외를 무시함
+        }
     }
 
     /**

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/EventEditService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/service/EventEditService.java
@@ -1,7 +1,10 @@
 package org.codeNbug.mainserver.domain.manager.service;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.codeNbug.mainserver.domain.event.dto.EventRegisterResponse;
 import org.codeNbug.mainserver.domain.event.entity.Event;
@@ -10,6 +13,11 @@ import org.codeNbug.mainserver.domain.event.entity.EventInformation;
 import org.codeNbug.mainserver.domain.manager.dto.EventRegisterRequest;
 import org.codeNbug.mainserver.domain.manager.repository.EventRepository;
 import org.codeNbug.mainserver.domain.manager.repository.ManagerEventRepository;
+import org.codeNbug.mainserver.domain.manager.service.EventDomainService;
+import org.codeNbug.mainserver.domain.notification.entity.NotificationEnum;
+import org.codeNbug.mainserver.domain.notification.service.NotificationService;
+import org.codeNbug.mainserver.domain.purchase.entity.Purchase;
+import org.codeNbug.mainserver.domain.purchase.repository.PurchaseRepository;
 import org.codeNbug.mainserver.domain.seat.entity.Seat;
 import org.codeNbug.mainserver.domain.seat.entity.SeatGrade;
 import org.codeNbug.mainserver.domain.seat.entity.SeatLayout;


### PR DESCRIPTION
## 🔎 작업 내용
기존 결제/환불/이벤트 발생 후에 실시간 알림 기능 추가

- [X] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)
- 결제 완료 시 사용자에게 알림 전송 (`confirmPayment`)
- 사용자 환불 요청 시 알림 전송 (`cancelPayment`)
- 매니저 일괄 환불 시 각 구매자에게 개별 알림 전송 (`managerCancelPayment`)
- 공연명, 시작일, 종료일 중 하나라도 변경 시, 해당 이벤트를 예매한 모든 사용자에게 알림 전송
- 이벤트 삭제 시 해당 공연을 예매한 모든 사용자에게 알림 전송


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
