### PR TITLE
feat: presigned url 방식 이미지 저장 로직 구현

### DIFF
--- a/service/main-server/build.gradle
+++ b/service/main-server/build.gradle
@@ -16,7 +16,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.653'
+    implementation platform("software.amazon.awssdk:bom:2.25.24")
+    implementation 'software.amazon.awssdk:s3'
     implementation project(':user')
     implementation project(':common')
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/controller/ImageUploadController.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/controller/ImageUploadController.java
@@ -1,0 +1,46 @@
+package org.codeNbug.mainserver.external.image.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.codeNbug.mainserver.external.image.dto.ImageUploadRequest;
+import org.codeNbug.mainserver.external.image.dto.ImageUploadResponse;
+import org.codeNbug.mainserver.external.image.service.S3PresignedUrlService;
+import org.codeNbug.mainserver.global.dto.RsData;
+import org.codenbug.user.domain.user.constant.UserRole;
+import org.codenbug.user.security.annotation.RoleRequired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/images")
+@RequiredArgsConstructor
+public class ImageUploadController {
+    private final S3PresignedUrlService s3PresignedUrlService;
+
+    /**
+     * presigned URL 배열 발급 (단일 or 다중 모두 배열로)
+     */
+    @RoleRequired({UserRole.MANAGER, UserRole.ADMIN})
+    @PostMapping("/url")
+    public ResponseEntity<RsData<List<ImageUploadResponse>>> getPresignedUrls(
+            @RequestBody ImageUploadRequest request
+    ) {
+        List<ImageUploadResponse> responses = request.getFileNames().stream()
+                .map(fileName -> new ImageUploadResponse(
+                        fileName,
+                        s3PresignedUrlService.generatePresignedUploadUrl(fileName, 10)
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(new RsData<>(
+                "200",
+                "presigned URL 발급 성공",
+                responses
+        ));
+    }
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/dto/ImageUploadRequest.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/dto/ImageUploadRequest.java
@@ -1,0 +1,12 @@
+package org.codeNbug.mainserver.external.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadRequest {
+    private List<String> fileNames;
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/dto/ImageUploadResponse.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/dto/ImageUploadResponse.java
@@ -1,0 +1,11 @@
+package org.codeNbug.mainserver.external.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadResponse {
+    private String fileName;
+    private String url;
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/service/S3PresignedUrlService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/service/S3PresignedUrlService.java
@@ -1,0 +1,50 @@
+package org.codeNbug.mainserver.external.image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class S3PresignedUrlService {
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${aws.region.static}")
+    private String region;
+
+
+    private final S3Client s3Client;
+    private final StaticCredentialsProvider credentialsProvider;
+
+    public String generatePresignedUploadUrl(String fileName, int expirationMinutes) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType("image/jpeg")
+                .build();
+
+        S3Presigner presigner = S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(
+                PutObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(expirationMinutes))
+                        .putObjectRequest(objectRequest)
+                        .build()
+        );
+
+        return presignedRequest.url().toString();
+    }
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/config/S3Config.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/config/S3Config.java
@@ -1,0 +1,38 @@
+package org.codeNbug.mainserver.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.region.static}")
+    private String region;
+
+    @Bean
+    public StaticCredentialsProvider awsCredentialsProvider() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+        return StaticCredentialsProvider.create(awsCreds);
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+}

--- a/service/main-server/src/main/resources/application.yml
+++ b/service/main-server/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -99,9 +99,3 @@ allowed:
   redirect:
     domains: localhost:3001,localhost:9000,code-bug.vercel.app
 
-cloud:
-  aws:
-    s3:
-      bucket: ${aws.s3.bucket}
-    region:
-      static: ${aws.region.static}


### PR DESCRIPTION
## 🔎 작업 내용
이미지 업로드 구현

- [x] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명
프론트에서 행사 생성 등 이미지 업로드가 필요할때, "/api/v1/images/url" 로 요청하여, 이미지를 저장할 수 있는 presigned url 을 받아, 프론트에서 저장한다.
이후 저장한 url 을 "행사 생성, 수정" 등 작업에서 요청 body 의 image url 값을 이미지 url 값으로 설정하여 요청할 수 있다.

### 📷 스크린샷
![image](https://github.com/user-attachments/assets/f8e7200e-34c9-4036-b2cf-12bd5921b204)



### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
