### PR TITLE
fix: s3 url 발급 시 이미지 파일의 확장자로 content-type 설정하도록 함.

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/service/S3PresignedUrlService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/external/image/service/S3PresignedUrlService.java
@@ -27,10 +27,12 @@ public class S3PresignedUrlService {
     private final StaticCredentialsProvider credentialsProvider;
 
     public String generatePresignedUploadUrl(String fileName, int expirationMinutes) {
+        String contentType = guessContentType(fileName); // 확장자 기반 추출
+
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileName)
-                .contentType("image/jpeg")
+                .contentType(contentType)
                 .build();
 
         S3Presigner presigner = S3Presigner.builder()
@@ -47,4 +49,23 @@ public class S3PresignedUrlService {
 
         return presignedRequest.url().toString();
     }
+
+
+    private String extractExtension(String fileName) {
+        String[] parts = fileName.split("\\.");
+        if (parts.length < 2) return ""; // 확장자 없음
+        return parts[parts.length - 1].toLowerCase(); // 마지막 요소가 확장자
+    }
+
+    private String guessContentType(String fileName) {
+        String ext = extractExtension(fileName);
+        return switch (ext) {
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "webp" -> "image/webp";
+            case "gif" -> "image/gif";
+            default -> "application/octet-stream"; // fallback
+        };
+    }
+
 }


### PR DESCRIPTION
## 🔎 작업 내용

url 생성 시 파일 형식으로 인한 저장 실패 해결

- [ ] ⚡️ 새로운 기능 추가
- [x] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)

파일명을 받아, url 의 content-type 을 설정하도록 변경함.

### 📷 스크린샷 (선택)

없음

### ✅ PR Checklist

@omegafrog  지우님, 해당 pr 확인해주시고, 이상 없으면 merge 후 배포 부탁드립니다!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
