### PR TITLE
Fix/좌석 조회 redis 버그

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/SeatService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/SeatService.java
@@ -199,6 +199,8 @@ public class SeatService {
 				throw new BadRequestException("[cancelSeat] 좌석 락을 해제할 수 없습니다.");
 			}
 			seat.cancelReserve();
+			String cacheKey = "seatLayout:" + eventId;
+			redisTemplate.delete(cacheKey);
 		}
 	}
 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/SeatTransactionService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/SeatTransactionService.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.codeNbug.mainserver.domain.seat.entity.Seat;
 import org.codeNbug.mainserver.domain.seat.repository.SeatRepository;
 import org.codeNbug.mainserver.global.exception.globalException.BadRequestException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class SeatTransactionService {
 	private final SeatRepository seatRepository;
 	private final RedisLockService redisLockService;
 	private static final String SEAT_LOCK_KEY_PREFIX = "seat:lock:";
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	@Transactional
 	public void reserveSeat(Seat seat, Long userId, Long eventId, Long seatId) {
@@ -36,7 +38,11 @@ public class SeatTransactionService {
 		try {
 			seat.reserve();
 			seatRepository.save(seat);
+			log.info("[reserveSeat] seat id {}가 예매되었습니다. 예매 상태: {}", seat.getId(), seat.isAvailable());
 
+			String cacheKey = "seatLayout:" + eventId;
+			redisTemplate.delete(cacheKey);
+			log.info("[reserveSeat] 행사 id {} 정보가 redis cache에서 삭제되었습니다.", eventId);
 		} catch (Exception e) {
 			// 예외 발생 시 즉시 락 해제
 			redisLockService.unlock(lockKey, lockValue);


### PR DESCRIPTION
## 🔎 작업 내용
redis cache에서 좌석 조회 시 예매 상태가 변경되어도 좌석 레이아웃 정보는 동일한 버그 수정

- [ ] ⚡️ 새로운 기능 추가
- [x] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [x] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)

없음

### 📷 스크린샷 (선택)

없음

### ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
