### PR TITLE
fix: utc -> kst 변환 deserializer 추가 및 event register request dto 에 적용

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/EventRegisterRequest.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/manager/dto/EventRegisterRequest.java
@@ -3,6 +3,7 @@ package org.codeNbug.mainserver.domain.manager.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.codeNbug.mainserver.domain.event.entity.EventCategoryEnum;
 import org.codeNbug.mainserver.domain.manager.dto.layout.LayoutDto;
 import org.codeNbug.mainserver.domain.manager.dto.layout.PriceDto;
@@ -11,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.codeNbug.mainserver.global.util.UtcToKstLocalDateTimeDeserializer;
 
 @Getter
 @NoArgsConstructor
@@ -22,14 +24,18 @@ public class EventRegisterRequest {
     private String description;
     private String restriction;
     private String thumbnailUrl;
+    @JsonDeserialize(using = UtcToKstLocalDateTimeDeserializer.class)
     private LocalDateTime startDate;
+    @JsonDeserialize(using = UtcToKstLocalDateTimeDeserializer.class)
     private LocalDateTime endDate;
     private String location;
     private String hallName;
     private int seatCount;
     private LayoutDto layout;
     private List<PriceDto> price;
+    @JsonDeserialize(using = UtcToKstLocalDateTimeDeserializer.class)
     private LocalDateTime bookingStart;
+    @JsonDeserialize(using = UtcToKstLocalDateTimeDeserializer.class)
     private LocalDateTime bookingEnd;
     private int agelimit;
 

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/config/TimeZoneConfig.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/config/TimeZoneConfig.java
@@ -1,0 +1,14 @@
+package org.codeNbug.mainserver.global.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+import java.util.TimeZone;
+
+@Component
+public class TimeZoneConfig {
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/util/UtcToKstLocalDateTimeDeserializer.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/util/UtcToKstLocalDateTimeDeserializer.java
@@ -1,0 +1,16 @@
+package org.codeNbug.mainserver.global.util;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.*;
+public class UtcToKstLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+    @Override
+    public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getText(); // "2025-05-21T05:21:11.579Z"
+        Instant instant = Instant.parse(value); // UTC 기준으로 Instant 생성
+        return LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul")); // KST로 변환
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

프론트에서 UTC 로 보낸 시간 정보를 KST 로 변환하여 DB 에 저장하도록 함.

- [x] ⚡️ 새로운 기능 추가
- [x] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)

프론트의 요청 중 시간정보 형식 : "2025-05-21T05:21:11.579Z"
사용자 입력 시간 -> UTC 로 변환 후 Z (UTC) 설정으로 보내고 있음.
이를 백엔드 서버에서 UTC -> KST 로 다시 변환이 필요함.
이를 위해 global/util/UtcToKstLocalDateTimeDeserializer.class 에서 처리하도록 함.

### 📷 스크린샷 (선택)

없음

### ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
