### PR TITLE
Fix: 좌석 TTL 만료 후 Redis Cache에 있는 좌석 정보 삭제

### DIFF
--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/RedisListenerService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/RedisListenerService.java
@@ -18,6 +18,7 @@ public class RedisListenerService implements MessageListener {
 
 	private final SeatRepository seatRepository;
 	private final EventRepository eventRepository;
+	private final SeatService seatService;
 	private static final String lockKeyPrefix = "seat:lock:";
 
 	/**
@@ -46,8 +47,9 @@ public class RedisListenerService implements MessageListener {
 					.orElseThrow(() -> new RuntimeException("[onMessage] 존재하지 않는 행사입니다."));
 				Seat seat = seatRepository.findById(seatId)
 					.orElseThrow(() -> new IllegalArgumentException("[onMessage] 좌석이 존재하지 않습니다."));
-				seat.setAvailable(true);
+				seat.cancelReserve();
 				seatRepository.save(seat);
+				seatService.evictSeatLayoutCache(eventId);
 
 				System.out.println("[onMessage] TTL 만료로 좌석 " + seatId + "의 상태가 available = true 로 변경되었습니다.");
 			} catch (NumberFormatException e) {

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/SeatTransactionService.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/domain/seat/service/SeatTransactionService.java
@@ -39,14 +39,15 @@ public class SeatTransactionService {
 			seat.reserve();
 			seatRepository.save(seat);
 			log.info("[reserveSeat] seat id {}가 예매되었습니다. 예매 상태: {}", seat.getId(), seat.isAvailable());
-
-			String cacheKey = "seatLayout:" + eventId;
-			redisTemplate.delete(cacheKey);
-			log.info("[reserveSeat] 행사 id {} 정보가 redis cache에서 삭제되었습니다.", eventId);
 		} catch (Exception e) {
 			// 예외 발생 시 즉시 락 해제
 			redisLockService.unlock(lockKey, lockValue);
+			seat.cancelReserve();
 			throw e;
 		}
+
+		String cacheKey = "seatLayout:" + eventId;
+		redisTemplate.delete(cacheKey);
+		log.info("[reserveSeat] 행사 id {} 정보가 redis cache에서 삭제되었습니다.", eventId);
 	}
 }

--- a/service/main-server/src/main/java/org/codeNbug/mainserver/global/Redis/config/RedisConfig.java
+++ b/service/main-server/src/main/java/org/codeNbug/mainserver/global/Redis/config/RedisConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -32,7 +32,7 @@ public class RedisConfig {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
 
-		container.addMessageListener(redisListenerService, new ChannelTopic("__keyevent@0__:expired"));
+		container.addMessageListener(redisListenerService, new PatternTopic("__keyevent@0__:expired"));
 		return container;
 	}
 


### PR DESCRIPTION
## 🔎 작업 내용

좌석 TTL 만료 후 Redis Cache에 있는 좌석 정보에 반영이 안되어 초기화 반영

- [ ] ⚡️ 새로운 기능 추가
- [x] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)

없음

### 📷 스크린샷 (선택)

없음

### ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
