### PR TITLE
Hotifx : 대기열 큐를 이벤트 당 하나 생성

### DIFF
--- a/service/common/src/main/java/org/codenbug/common/util/CookieUtil.java
+++ b/service/common/src/main/java/org/codenbug/common/util/CookieUtil.java
@@ -36,7 +36,7 @@ public class CookieUtil {
 		Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, token);
 		cookie.setMaxAge((int)(accessTokenExpiration / 1000)); // milliseconds to seconds
 		cookie.setPath(COOKIE_PATH);
-		// cookie.setDomain(cookieDomain);
+		cookie.setDomain(cookieDomain);
 		cookie.setHttpOnly(true);
 
 		// 개발 환경 확인 (localhost에서는 secure=false로 설정)
@@ -78,7 +78,7 @@ public class CookieUtil {
 		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, token);
 		cookie.setMaxAge((int)(refreshTokenExpiration / 1000)); // milliseconds to seconds
 		cookie.setPath(COOKIE_PATH);
-		// cookie.setDomain(cookieDomain);
+		cookie.setDomain(cookieDomain);
 		cookie.setHttpOnly(true);
 
 		// 개발 환경 확인 (localhost에서는 secure=false로 설정)

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/redis/RedisConfig.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/redis/RedisConfig.java
@@ -59,7 +59,6 @@ public class RedisConfig {
 		} catch (Exception e) {
 			redisTemplate.opsForStream().createGroup(ENTRY_QUEUE_KEY_NAME, ENTRY_QUEUE_GROUP_NAME);
 		}
-		redisTemplate.opsForValue().set(ENTRY_QUEUE_COUNT_KEY_NAME, ENTRY_QUEUE_CAPACITY);
 
 		return redisTemplate;
 	}

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/redis/RedisConfig.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/redis/RedisConfig.java
@@ -40,17 +40,6 @@ public class RedisConfig {
 		// 컨슈머 그룹이 없으면 새로운 컨슈머 그룹 생성
 		try {
 			if (redisTemplate.opsForStream()
-				.groups(WAITING_QUEUE_KEY_NAME)
-				.stream()
-				.noneMatch(xInfoGroup -> xInfoGroup.groupName().equals(WAITING_QUEUE_GROUP_NAME))) {
-				redisTemplate.opsForStream().createGroup(WAITING_QUEUE_KEY_NAME, WAITING_QUEUE_GROUP_NAME);
-			}
-
-		} catch (Exception e) {
-			redisTemplate.opsForStream().createGroup(WAITING_QUEUE_KEY_NAME, WAITING_QUEUE_GROUP_NAME);
-		}
-		try {
-			if (redisTemplate.opsForStream()
 				.groups(ENTRY_QUEUE_KEY_NAME)
 				.stream()
 				.noneMatch(xInfoGroup -> xInfoGroup.groupName().equals(ENTRY_QUEUE_GROUP_NAME))) {
@@ -59,7 +48,6 @@ public class RedisConfig {
 		} catch (Exception e) {
 			redisTemplate.opsForStream().createGroup(ENTRY_QUEUE_KEY_NAME, ENTRY_QUEUE_GROUP_NAME);
 		}
-
 		return redisTemplate;
 	}
 

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
@@ -1,9 +1,10 @@
 package org.codenbug.messagedispatcher.thread;
 
+import static org.codenbug.messagedispatcher.redis.RedisConfig.*;
+
 import java.util.List;
 import java.util.Map;
 
-import org.codenbug.messagedispatcher.redis.RedisConfig;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.StreamRecords;
@@ -27,85 +28,106 @@ public class EntryPromoteThread {
 
 	@Scheduled(cron = "* * * * * *")
 	public void promoteToEntryQueue() {
+		// 1) waiting 스트림의 모든 레코드를 조회
+		redisTemplate.keys(WAITING_QUEUE_KEY_NAME + ":*").forEach(key -> {
+			doPromote(key);
+		});
+	}
+
+	private void doPromote(String key) {
+		// waiting stream에 consumer group이 없다면 만들어 줘야 함.
+		try {
+			if (redisTemplate.opsForStream()
+				.groups(key)
+				.stream()
+				.noneMatch(xInfoGroup -> xInfoGroup.groupName().equals(WAITING_QUEUE_GROUP_NAME))) {
+				redisTemplate.opsForStream().createGroup(key, WAITING_QUEUE_GROUP_NAME);
+			}
+
+		} catch (Exception e) {
+			redisTemplate.opsForStream().createGroup(key, WAITING_QUEUE_GROUP_NAME);
+		}
+
 		StreamOperations<String, Object, Object> streamOps = redisTemplate.opsForStream();
 		HashOperations<String, String, Object> hashOps = redisTemplate.opsForHash();
 
-		// 1) waiting 스트림의 모든 레코드를 조회
+		// 해당 키의 스트림 내의 모든 메시지 얻기
 		List<MapRecord<String, Object, Object>> records =
-			streamOps.range(RedisConfig.WAITING_QUEUE_KEY_NAME, Range.unbounded());
+			streamOps.range(key, Range.unbounded());
 
 		for (MapRecord<String, Object, Object> record : records) {
+			// 메시지 내 데이터 파싱
 			Long userId = Long.parseLong(record.getValue().get("userId").toString());
 			Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
 			String instanceId = String.valueOf(record.getValue().get("instanceId"));
 
-			// 이 스트림 메시지에 해당하는 유저가 이벤트의 entry queue에 들어갈수 있는지 검사
+			// 이 waiting 스트림 메시지에 해당하는 유저가 이벤트의 entry queue에 들어갈수 있는지 검사
 			// 해당 event의 entry queue count를 조회
-
 			Long queueCount = Long.parseLong(
-				hashOps.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString()).toString());
-			if (queueCount != null && queueCount > 1) {
-				// 2) 카운트 감소
-				Long tmp = hashOps.increment(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString(), -1);
-				System.out.println("tmp = " + tmp);
-				System.out.println("eventId.toString() = " + eventId.toString());
+				hashOps.get(ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString()).toString());
+			// 이 값이 1 이상이라면 들어갈 자리가 있다는 뜻이므로 유저를 entry queue로 넣음
+			if (queueCount != null && queueCount > 0) {
+
+				// 2) 해당 event의 entry queue count 1만큼 감소
+				Long tmp = hashOps.increment(ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString(), -1);
+
 				// entry queue message를 생성
 				redisTemplate.opsForStream()
 					.add(StreamRecords.mapBacked(
 						Map.of("userId", userId, "eventId", eventId, "instanceId", instanceId)
-					).withStreamKey(RedisConfig.ENTRY_QUEUE_KEY_NAME));
+					).withStreamKey(ENTRY_QUEUE_KEY_NAME));
+
 				// 3) 스트림 ACK
-				streamOps.acknowledge(RedisConfig.WAITING_QUEUE_KEY_NAME, RedisConfig.WAITING_QUEUE_GROUP_NAME,
+				streamOps.acknowledge(key, WAITING_QUEUE_GROUP_NAME,
 					record.getId());
 
 				// 4) 스트림에서 해당 레코드 삭제
-				streamOps.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, record.getId());
+				streamOps.delete(key, record.getId());
 
-				hashOps.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId.toString(),
+				hashOps.delete(WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId.toString(),
 					userId.toString());
 			}
 		}
-		// // promote할 갯수 얻음
-		//
-		// Set<String> keys = redisTemplate.keys(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME + ":*");
-		//
-		// Long count = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue()
-		// 	.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME)).toString());
-		// // 갯수만큼 waiting queue에서 가져옴
-		// List<MapRecord<String, Object, Object>> promoteTarget = redisTemplate.opsForStream()
-		// 	.read(Consumer.from(
-		// 			RedisConfig.WAITING_QUEUE_GROUP_NAME, RedisConfig.WAITING_QUEUE_CONSUMER_NAME),
-		// 		StreamReadOptions.empty().count(count), StreamOffset.create(
-		// 			RedisConfig.WAITING_QUEUE_KEY_NAME, ReadOffset.lastConsumed()
-		// 		));
-		//
-		// assert promoteTarget != null;
-		// promoteTarget.forEach(
-		// 	record -> {
-		// 		// waiting queue message에서 userId, eventId, instanceId 추출
-		// 		Long userId = Long.parseLong(record.getValue().get("userId").toString());
-		// 		Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
-		// 		String instanceId = String.valueOf(record.getValue().get("instanceId"));
-		//
-		// 		// entry queue message를 생성
-		// 		redisTemplate.opsForStream()
-		// 			.add(StreamRecords.mapBacked(
-		// 				Map.of("userId", userId, "eventId", eventId, "instanceId", instanceId)
-		// 			).withStreamKey(RedisConfig.ENTRY_QUEUE_KEY_NAME));
-		//
-		// 		// waiting queue에서 메시지를 consume했음을 알림 (ack)
-		// 		redisTemplate.opsForStream()
-		// 			.acknowledge(RedisConfig.WAITING_QUEUE_KEY_NAME, RedisConfig.WAITING_QUEUE_GROUP_NAME,
-		// 				record.getId());
-		// 		// waiting queue에서 consume한 메시지를 삭제
-		// 		redisTemplate.opsForStream()
-		// 			.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, record.getId());
-		//
-		// 		// WAITING_USER_ID에서 삭제
-		// 		redisTemplate.opsForHash()
-		// 			.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId, userId.toString());
-		// 	}
-		// );
-
 	}
 }
+
+//
+// Set<String> keys = redisTemplate.keys(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME + ":*");
+//
+// Long count = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue()
+// 	.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME)).toString());
+// // 갯수만큼 waiting queue에서 가져옴
+// List<MapRecord<String, Object, Object>> promoteTarget = redisTemplate.opsForStream()
+// 	.read(Consumer.from(
+// 			RedisConfig.WAITING_QUEUE_GROUP_NAME, RedisConfig.WAITING_QUEUE_CONSUMER_NAME),
+// 		StreamReadOptions.empty().count(count), StreamOffset.create(
+// 			RedisConfig.WAITING_QUEUE_KEY_NAME, ReadOffset.lastConsumed()
+// 		));
+//
+// assert promoteTarget != null;
+// promoteTarget.forEach(
+// 	record -> {
+// 		// waiting queue message에서 userId, eventId, instanceId 추출
+// 		Long userId = Long.parseLong(record.getValue().get("userId").toString());
+// 		Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
+// 		String instanceId = String.valueOf(record.getValue().get("instanceId"));
+//
+// 		// entry queue message를 생성
+// 		redisTemplate.opsForStream()
+// 			.add(StreamRecords.mapBacked(
+// 				Map.of("userId", userId, "eventId", eventId, "instanceId", instanceId)
+// 			).withStreamKey(RedisConfig.ENTRY_QUEUE_KEY_NAME));
+//
+// 		// waiting queue에서 메시지를 consume했음을 알림 (ack)
+// 		redisTemplate.opsForStream()
+// 			.acknowledge(RedisConfig.WAITING_QUEUE_KEY_NAME, RedisConfig.WAITING_QUEUE_GROUP_NAME,
+// 				record.getId());
+// 		// waiting queue에서 consume한 메시지를 삭제
+// 		redisTemplate.opsForStream()
+// 			.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, record.getId());
+//
+// 		// WAITING_USER_ID에서 삭제
+// 		redisTemplate.opsForHash()
+// 			.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId, userId.toString());
+// 	}
+// );

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
@@ -3,6 +3,7 @@ package org.codenbug.messagedispatcher.thread;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.codenbug.messagedispatcher.redis.RedisConfig;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -30,9 +31,11 @@ public class EntryPromoteThread {
 	@Scheduled(cron = "* * * * * *")
 	public void promoteToEntryQueue() {
 		// promote할 갯수 얻음
+
+		Set<String> keys = redisTemplate.keys(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME + ":*");
+
 		Long count = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue()
 			.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME)).toString());
-
 		// 갯수만큼 waiting queue에서 가져옴
 		List<MapRecord<String, Object, Object>> promoteTarget = redisTemplate.opsForStream()
 			.read(Consumer.from(

--- a/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
+++ b/service/message-dispatcher/src/main/java/org/codenbug/messagedispatcher/thread/EntryPromoteThread.java
@@ -2,17 +2,14 @@ package org.codenbug.messagedispatcher.thread;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 
 import org.codenbug.messagedispatcher.redis.RedisConfig;
-import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -30,52 +27,85 @@ public class EntryPromoteThread {
 
 	@Scheduled(cron = "* * * * * *")
 	public void promoteToEntryQueue() {
-		// promote할 갯수 얻음
+		StreamOperations<String, Object, Object> streamOps = redisTemplate.opsForStream();
+		HashOperations<String, String, Object> hashOps = redisTemplate.opsForHash();
 
-		Set<String> keys = redisTemplate.keys(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME + ":*");
+		// 1) waiting 스트림의 모든 레코드를 조회
+		List<MapRecord<String, Object, Object>> records =
+			streamOps.range(RedisConfig.WAITING_QUEUE_KEY_NAME, Range.unbounded());
 
-		Long count = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue()
-			.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME)).toString());
-		// 갯수만큼 waiting queue에서 가져옴
-		List<MapRecord<String, Object, Object>> promoteTarget = redisTemplate.opsForStream()
-			.read(Consumer.from(
-					RedisConfig.WAITING_QUEUE_GROUP_NAME, RedisConfig.WAITING_QUEUE_CONSUMER_NAME),
-				StreamReadOptions.empty().count(count), StreamOffset.create(
-					RedisConfig.WAITING_QUEUE_KEY_NAME, ReadOffset.lastConsumed()
-				));
+		for (MapRecord<String, Object, Object> record : records) {
+			Long userId = Long.parseLong(record.getValue().get("userId").toString());
+			Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
+			String instanceId = String.valueOf(record.getValue().get("instanceId"));
 
-		assert promoteTarget != null;
-		promoteTarget.forEach(
-			record -> {
-				// waiting queue message에서 userId, eventId, instanceId 추출
-				Long userId = Long.parseLong(record.getValue().get("userId").toString());
-				Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
-				String instanceId = String.valueOf(record.getValue().get("instanceId"));
+			// 이 스트림 메시지에 해당하는 유저가 이벤트의 entry queue에 들어갈수 있는지 검사
+			// 해당 event의 entry queue count를 조회
 
+			Long queueCount = Long.parseLong(
+				hashOps.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString()).toString());
+			if (queueCount != null && queueCount > 1) {
+				// 2) 카운트 감소
+				Long tmp = hashOps.increment(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString(), -1);
+				System.out.println("tmp = " + tmp);
+				System.out.println("eventId.toString() = " + eventId.toString());
 				// entry queue message를 생성
 				redisTemplate.opsForStream()
 					.add(StreamRecords.mapBacked(
 						Map.of("userId", userId, "eventId", eventId, "instanceId", instanceId)
 					).withStreamKey(RedisConfig.ENTRY_QUEUE_KEY_NAME));
+				// 3) 스트림 ACK
+				streamOps.acknowledge(RedisConfig.WAITING_QUEUE_KEY_NAME, RedisConfig.WAITING_QUEUE_GROUP_NAME,
+					record.getId());
 
-				// waiting queue에서 메시지를 consume했음을 알림 (ack)
-				redisTemplate.opsForStream()
-					.acknowledge(RedisConfig.WAITING_QUEUE_KEY_NAME, RedisConfig.WAITING_QUEUE_GROUP_NAME,
-						record.getId());
-				// waiting queue에서 consume한 메시지를 삭제
-				redisTemplate.opsForStream()
-					.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, record.getId());
+				// 4) 스트림에서 해당 레코드 삭제
+				streamOps.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, record.getId());
 
-				// WAITING_USER_ID에서 삭제
-				redisTemplate.opsForHash()
-					.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId, userId.toString());
+				hashOps.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId.toString(),
+					userId.toString());
 			}
-		);
-		// entry queue의 최대 크기에서 waiting queue에서 가져온 갯수만큼을 뺀 갯수를 저장.
-		// 다음번에 가져올 최대 갯수를 계산해 저장
-		if (!promoteTarget.isEmpty()) {
-			redisTemplate.opsForValue()
-				.set(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, RedisConfig.ENTRY_QUEUE_CAPACITY - promoteTarget.size());
 		}
+		// // promote할 갯수 얻음
+		//
+		// Set<String> keys = redisTemplate.keys(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME + ":*");
+		//
+		// Long count = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue()
+		// 	.get(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME)).toString());
+		// // 갯수만큼 waiting queue에서 가져옴
+		// List<MapRecord<String, Object, Object>> promoteTarget = redisTemplate.opsForStream()
+		// 	.read(Consumer.from(
+		// 			RedisConfig.WAITING_QUEUE_GROUP_NAME, RedisConfig.WAITING_QUEUE_CONSUMER_NAME),
+		// 		StreamReadOptions.empty().count(count), StreamOffset.create(
+		// 			RedisConfig.WAITING_QUEUE_KEY_NAME, ReadOffset.lastConsumed()
+		// 		));
+		//
+		// assert promoteTarget != null;
+		// promoteTarget.forEach(
+		// 	record -> {
+		// 		// waiting queue message에서 userId, eventId, instanceId 추출
+		// 		Long userId = Long.parseLong(record.getValue().get("userId").toString());
+		// 		Long eventId = Long.parseLong(record.getValue().get("eventId").toString());
+		// 		String instanceId = String.valueOf(record.getValue().get("instanceId"));
+		//
+		// 		// entry queue message를 생성
+		// 		redisTemplate.opsForStream()
+		// 			.add(StreamRecords.mapBacked(
+		// 				Map.of("userId", userId, "eventId", eventId, "instanceId", instanceId)
+		// 			).withStreamKey(RedisConfig.ENTRY_QUEUE_KEY_NAME));
+		//
+		// 		// waiting queue에서 메시지를 consume했음을 알림 (ack)
+		// 		redisTemplate.opsForStream()
+		// 			.acknowledge(RedisConfig.WAITING_QUEUE_KEY_NAME, RedisConfig.WAITING_QUEUE_GROUP_NAME,
+		// 				record.getId());
+		// 		// waiting queue에서 consume한 메시지를 삭제
+		// 		redisTemplate.opsForStream()
+		// 			.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, record.getId());
+		//
+		// 		// WAITING_USER_ID에서 삭제
+		// 		redisTemplate.opsForHash()
+		// 			.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + eventId, userId.toString());
+		// 	}
+		// );
+
 	}
 }

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/RedisConfig.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/RedisConfig.java
@@ -77,17 +77,6 @@ public class RedisConfig {
 			redisTemplate.opsForStream()
 				.createGroup(WAITING_QUEUE_KEY_NAME, WAITING_QUEUE_GROUP_NAME + ":" + instanceId);
 		}
-		// 메시지 idx 데이터가 없다면 생성.
-		if (redisTemplate.opsForValue().get(WAITING_QUEUE_IDX_KEY_NAME) == null) {
-			redisTemplate.opsForValue()
-				.set(WAITING_QUEUE_IDX_KEY_NAME, 0L);
-		}
-		// entry queue count 데이터가 없다면 생성
-		if (redisTemplate.opsForValue().get(ENTRY_QUEUE_COUNT_KEY_NAME) == null) {
-			redisTemplate.opsForValue()
-				.set(ENTRY_QUEUE_COUNT_KEY_NAME, ENTRY_QUEUE_CAPACITY);
-		}
-		redisTemplate.opsForValue().set(ENTRY_QUEUE_COUNT_KEY_NAME, ENTRY_QUEUE_CAPACITY);
 		return redisTemplate;
 	}
 }

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/RedisConfig.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/external/redis/RedisConfig.java
@@ -32,6 +32,7 @@ public class RedisConfig {
 	public static final String DISPATCH_QUEUE_CHANNEL_NAME = "DISPATCH";
 	public static final String WAITING_QUEUE_IN_USER_RECORD_KEY_NAME = "WAITING_USER_ID";
 	public static final String ENTRY_TOKEN_STORAGE_KEY_NAME = "ENTRY_TOKEN";
+	public static final String WAITING_QUEUE_START_IDX_KEY = "WAITING_QUEUE_START_IDX";
 	private static final String ENTRY_USER_STREAM_GROUP = "ENTRY_CONSUMER_GROUP";
 
 	@Value("${custom.instance-id}")
@@ -63,20 +64,6 @@ public class RedisConfig {
 		redisTemplate.setValueSerializer(jsonSerializer);
 		redisTemplate.afterPropertiesSet();
 
-		// 컨슈머 그룹이 없으면 새로운 컨슈머 그룹 생성
-		try {
-			if (!redisTemplate.opsForStream()
-				.groups(WAITING_QUEUE_KEY_NAME).stream().anyMatch(
-					xInfoGroup -> xInfoGroup.groupName().equals(WAITING_QUEUE_GROUP_NAME + ":" + instanceId)
-				)) {
-				redisTemplate.opsForStream()
-					.createGroup(WAITING_QUEUE_KEY_NAME, WAITING_QUEUE_GROUP_NAME + ":" + instanceId);
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			redisTemplate.opsForStream()
-				.createGroup(WAITING_QUEUE_KEY_NAME, WAITING_QUEUE_GROUP_NAME + ":" + instanceId);
-		}
 		return redisTemplate;
 	}
 }

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/controller/WaitingQueueController.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/controller/WaitingQueueController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
@@ -47,7 +49,7 @@ public class WaitingQueueController {
 	@RoleRequired({UserRole.USER})
 	@GetMapping(value = "/events/{id}/tickets/waiting", produces = MediaType.TEXT_EVENT_STREAM_VALUE
 		+ ";charset=UTF-8")
-	public SseEmitter entryWaiting(@PathVariable("id") Long eventId) {
+	public SseEmitter entryWaiting(@PathVariable("id") Long eventId) throws JsonProcessingException {
 		return waitingQueueEntryService.entry(eventId);
 	}
 }

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/SseEmitterService.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/SseEmitterService.java
@@ -36,12 +36,16 @@ public class SseEmitterService {
 		// emitter연결이 끊어질 때 만약 entry상태라면 entry count를 1 증가
 		emitter.onCompletion(() -> {
 			log.info("emitter completed");
+			// 커넥션 정보 얻기
 			SseConnection sseConnection = emitterMap.get(userId);
 			Status status = sseConnection.getStatus();
+			// 커넥션 정보로부터 이벤트 아이디 얻기
 			String parsedEventId = sseConnection.getEventId().toString();
+			// 대기열 탈출 상태에서 커넥션이 종료되었다면
+			// entry_queue_count를 1 감소시킨 것을 다시 증가
 			if (status.equals(Status.IN_ENTRY)) {
-				redisTemplate.opsForValue()
-					.increment(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, 1);
+				redisTemplate.opsForHash()
+					.increment(RedisConfig.ENTRY_QUEUE_COUNT_KEY_NAME, parsedEventId, 1);
 			} else if (status.equals(Status.IN_QUEUE)) {
 				String recordIdString = redisTemplate.opsForHash()
 					.get(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + parsedEventId,
@@ -50,7 +54,7 @@ public class SseEmitterService {
 				RecordId recordId = RecordId.of(recordIdString);
 
 				redisTemplate.opsForStream()
-					.delete(RedisConfig.WAITING_QUEUE_KEY_NAME, recordId);
+					.delete(RedisConfig.WAITING_QUEUE_KEY_NAME + ":" + eventId, recordId);
 				redisTemplate.opsForHash()
 					.delete(RedisConfig.WAITING_QUEUE_IN_USER_RECORD_KEY_NAME + ":" + parsedEventId,
 						userId.toString());

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/SseEmitterService.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/SseEmitterService.java
@@ -39,8 +39,10 @@ public class SseEmitterService {
 			// 커넥션 정보 얻기
 			SseConnection sseConnection = emitterMap.get(userId);
 			Status status = sseConnection.getStatus();
+
 			// 커넥션 정보로부터 이벤트 아이디 얻기
 			String parsedEventId = sseConnection.getEventId().toString();
+
 			// 대기열 탈출 상태에서 커넥션이 종료되었다면
 			// entry_queue_count를 1 감소시킨 것을 다시 증가
 			if (status.equals(Status.IN_ENTRY)) {

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/WaitingQueueEntryService.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/WaitingQueueEntryService.java
@@ -66,7 +66,7 @@ public class WaitingQueueEntryService {
 	 * @param eventId 행사의 id
 	 */
 	private void enter(Long userId, Long eventId) throws JsonProcessingException {
-
+		// 총 좌석수 얻기
 		RestTemplate restTemplate = new RestTemplate();
 
 		ResponseEntity<String> forEntity = restTemplate.getForEntity(
@@ -80,7 +80,7 @@ public class WaitingQueueEntryService {
 			.get("seatCount")
 			.asInt();
 
-		if (simpleRedisTemplate.keys(ENTRY_QUEUE_COUNT_KEY_NAME + ":" + eventId.toString()).isEmpty()) {
+		if (!simpleRedisTemplate.opsForHash().hasKey(ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString())) {
 			simpleRedisTemplate.opsForHash()
 				.put(ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString(), seatCount);
 		}
@@ -106,7 +106,7 @@ public class WaitingQueueEntryService {
 			.add(StreamRecords.mapBacked(
 				Map.of(QUEUE_MESSAGE_IDX_KEY_NAME, idx, QUEUE_MESSAGE_USER_ID_KEY_NAME, userId,
 					QUEUE_MESSAGE_EVENT_ID_KEY_NAME, eventId, QUEUE_MESSAGE_INSTANCE_ID_KEY_NAME, instanceId)
-			).withStreamKey(WAITING_QUEUE_KEY_NAME));
+			).withStreamKey(WAITING_QUEUE_KEY_NAME + ":" + eventId.toString()));
 
 		assert recordId != null;
 		// 유저가 대기열에 있는지 확인하기 위한 hash 값 업데이트

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/WaitingQueueEntryService.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/service/WaitingQueueEntryService.java
@@ -4,7 +4,6 @@ import static org.codeNbug.queueserver.external.redis.RedisConfig.*;
 
 import java.util.Map;
 
-import org.codeNbug.queueserver.external.redis.RedisConfig;
 import org.codenbug.user.domain.user.repository.UserRepository;
 import org.codenbug.user.security.exception.AuthenticationFailedException;
 import org.codenbug.user.security.service.CustomUserDetails;
@@ -13,10 +12,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class WaitingQueueEntryService {
@@ -24,18 +28,25 @@ public class WaitingQueueEntryService {
 	private final SseEmitterService sseEmitterService;
 	private final RedisTemplate<String, Object> simpleRedisTemplate;
 	private final UserRepository userRepository;
+	private final ObjectMapper objectMapper;
+	private final RedisTemplate<Object, Object> redisTemplate;
+	@Value("${custom.backend.url}")
+	private String url;
 
 	@Value("${custom.instance-id}")
 	private String instanceId;
 
 	public WaitingQueueEntryService(SseEmitterService sseEmitterService,
-		RedisTemplate<String, Object> simpleRedisTemplate, UserRepository userRepository) {
+		RedisTemplate<String, Object> simpleRedisTemplate, UserRepository userRepository, ObjectMapper objectMapper,
+		RedisTemplate<Object, Object> redisTemplate) {
 		this.sseEmitterService = sseEmitterService;
 		this.simpleRedisTemplate = simpleRedisTemplate;
 		this.userRepository = userRepository;
+		this.objectMapper = objectMapper;
+		this.redisTemplate = redisTemplate;
 	}
 
-	public SseEmitter entry(Long eventId) {
+	public SseEmitter entry(Long eventId) throws JsonProcessingException {
 		// 로그인한 유저 id 조회
 		Long id = getLoggedInUserId();
 
@@ -54,11 +65,30 @@ public class WaitingQueueEntryService {
 	 * @param userId 대기열에 추가할 유저 id
 	 * @param eventId 행사의 id
 	 */
-	private void enter(Long userId, Long eventId) {
+	private void enter(Long userId, Long eventId) throws JsonProcessingException {
+
+		RestTemplate restTemplate = new RestTemplate();
+
+		ResponseEntity<String> forEntity = restTemplate.getForEntity(
+			url + "/api/v1/events/" + eventId, String.class);
+
+		System.out.println("forEntity.getBody().toString() = " + forEntity.getBody().toString());
+
+		int seatCount = objectMapper.readTree(forEntity.getBody())
+			.get("data")
+			.get("information")
+			.get("seatCount")
+			.asInt();
+
+		if (simpleRedisTemplate.keys(ENTRY_QUEUE_COUNT_KEY_NAME + ":" + eventId.toString()).isEmpty()) {
+			simpleRedisTemplate.opsForHash()
+				.put(ENTRY_QUEUE_COUNT_KEY_NAME, eventId.toString(), seatCount);
+		}
+
 
 		// 대기열 큐 idx 추가
-		Long idx = simpleRedisTemplate.opsForValue()
-			.increment(RedisConfig.WAITING_QUEUE_IDX_KEY_NAME);
+		Long idx = simpleRedisTemplate.opsForHash()
+			.increment(WAITING_QUEUE_IDX_KEY_NAME, eventId.toString(), 1);
 
 		// 유저가 대기열에 있었는지 확인하기 위한 hash 값 조회
 		Boolean isEntered = simpleRedisTemplate.opsForHash()

--- a/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/thread/QueueInfoScheduler.java
+++ b/service/queue-server/src/main/java/org/codeNbug/queueserver/waitingqueue/thread/QueueInfoScheduler.java
@@ -49,16 +49,18 @@ public class QueueInfoScheduler {
 			return;
 		}
 
-		// queue의 첫번째 요소의 idx 가져옵니다.
-		Long firstIdx = Long.parseLong(
-			waitingList.getFirst().getValue().get(QUEUE_MESSAGE_IDX_KEY_NAME).toString());
+
 
 		// 대기열 큐에 있는 모든 유저들에게 대기열 순번과 userId, eventId를 전송합니다.
 		for (MapRecord<String, Object, Object> record : waitingList) {
-			// 대기열 큐 메시지로부터 데이터를 파싱합니다.
 			Long userId = Long.parseLong(record.getValue().get(QUEUE_MESSAGE_USER_ID_KEY_NAME).toString());
 			Long eventId = Long.parseLong(record.getValue().get(QUEUE_MESSAGE_EVENT_ID_KEY_NAME).toString());
 			Long idx = Long.parseLong(record.getValue().get(QUEUE_MESSAGE_IDX_KEY_NAME).toString());
+
+			Long firstIdx = Long.parseLong(
+				redisTemplate.opsForHash().get(WAITING_QUEUE_START_IDX_KEY, eventId.toString()).toString());
+
+			// 대기열 큐 메시지로부터 데이터를 파싱합니다.
 
 			if (!emitterMap.containsKey(userId)) {
 				log.debug("user %d가 연결이 끊어진 상태입니다.".formatted(userId));

--- a/service/queue-server/src/main/resources/application-prod.yml
+++ b/service/queue-server/src/main/resources/application-prod.yml
@@ -14,3 +14,6 @@ spring:
 cookie:
   domain: localhost
   secure: false  # dev 환경에서는 false, prod 환경에서는 true로 설정
+custom:
+  backend:
+    url: https://api.main.ticketone.site


### PR DESCRIPTION
## 🔎 작업 내용

모든 대기열 메시지를 하나의 큐에 담는 것을 이벤트당 하나의 큐를 생성하도록 수정했습니다.

- [ ] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)

waiting_queue가 각각의 event마다 하나 생기도록 수정
이에 따른 로직 일부 수정

### 추가 구현 필요 사항
booking 시간이 끝나거나 이벤트가 삭제될 때 해당 waiting queue 스트림을 삭제하도록 하는 것이 효율적일 것이다.

### 📷 스크린샷 (선택)

없음

### ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
